### PR TITLE
added-dependencies maven plugin parameter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -176,6 +176,27 @@ The fragment below was taken directly from the integration tests present in this
 Many parameters are actually used to tweak and configure the Closure compiler. Refer to the Closure documentation for
 more information.
 
+
+
+## added-dependencies
+A list of artifacts (group-id colon artifact-id) followed by a comma separated list of artifacts that will become
+dependencies of the former. This is equivalent to defining the later as `<dependency>` in the former `pom.xml`.
+
+This is necessary in a few dependencies such as [com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT](https://github.com/Vertispan/jsinterop-base)
+requiring annotations like `javaemul.internal.annotations.DoNotAutobox` but are missing a `<dependency>` declaration
+for [com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT](https://github.com/Vertispan/j2cl/blob/rebased_master/maven/gwt-internal-annotations/pom.xml);
+This mechanism provides support for adding such missing dependencies at an individual artifact level.
+
+The same is true for the original google artifacts such as `com.google.jsinterop:jsinterop-annotations:1.0.2`
+
+```xml
+<added-dependencies>
+    <param>com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT</param>
+</added-dependencies>
+```
+
+
+
 ## classpath-scope
 The suggested value is typically `runtime`, for more info click [here](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html)
 

--- a/sample.pom.xml
+++ b/sample.pom.xml
@@ -139,6 +139,9 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <added-dependencies>
+                                <param>com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT</param>
+                            </added-dependencies>
                             <classpath-scope>runtime</classpath-scope>
                             <compilation-level>ADVANCED</compilation-level>
                             <defines>

--- a/src/it/example-dependency-exclusion/example-dependency-exclusions-app/pom.xml
+++ b/src/it/example-dependency-exclusion/example-dependency-exclusions-app/pom.xml
@@ -84,6 +84,9 @@
               <goal>build</goal>
             </goals>
             <configuration>
+              <added-dependencies>
+                <param>com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT</param>
+              </added-dependencies>
               <classpath-scope>runtime</classpath-scope>
               <compilation-level>ADVANCED</compilation-level>
               <defines>

--- a/src/it/example-hello-world-reactor/app/pom.xml
+++ b/src/it/example-hello-world-reactor/app/pom.xml
@@ -31,6 +31,9 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <added-dependencies>
+                                <param>com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT</param>
+                            </added-dependencies>
                             <classpath-scope>runtime</classpath-scope>
                             <compilation-level>ADVANCED</compilation-level>
                             <defines>

--- a/src/it/example-hello-world-single/pom.xml
+++ b/src/it/example-hello-world-single/pom.xml
@@ -70,6 +70,9 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <added-dependencies>
+                                <param>com.vertispan.jsinterop:base:jar:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT</param>
+                            </added-dependencies>
                             <classpath-scope>runtime</classpath-scope>
                             <compilation-level>ADVANCED</compilation-level>
                             <defines>

--- a/src/main/java/walkingkooka/j2cl/maven/J2clBuildRequest.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clBuildRequest.java
@@ -46,7 +46,8 @@ import java.util.stream.Collectors;
  */
 final class J2clBuildRequest {
 
-    static J2clBuildRequest with(final J2clClasspathScope scope,
+    static J2clBuildRequest with(final Map<J2clArtifactCoords, List<J2clArtifactCoords>> addedDependencies,
+                                 final J2clClasspathScope scope,
                                  final CompilationLevel level,
                                  final Map<String, String> defines,
                                  final Set<String> externs,
@@ -62,7 +63,8 @@ final class J2clBuildRequest {
                                  final J2clMavenMiddleware middleware,
                                  final ExecutorService executor,
                                  final J2clLogger logger) {
-        return new J2clBuildRequest(scope,
+        return new J2clBuildRequest(addedDependencies,
+                scope,
                 level,
                 defines,
                 externs,
@@ -80,7 +82,8 @@ final class J2clBuildRequest {
                 logger);
     }
 
-    private J2clBuildRequest(final J2clClasspathScope scope,
+    private J2clBuildRequest(final Map<J2clArtifactCoords, List<J2clArtifactCoords>> addedDependencies,
+                             final J2clClasspathScope scope,
                              final CompilationLevel level,
                              final Map<String, String> defines,
                              final Set<String> externs,
@@ -97,6 +100,8 @@ final class J2clBuildRequest {
                              final ExecutorService executor,
                              final J2clLogger logger) {
         super();
+
+        this.addedDependencies = addedDependencies;
 
         this.scope = scope;
         this.level = level;
@@ -134,6 +139,19 @@ final class J2clBuildRequest {
         this.hash = hash
                 .toString();
     }
+
+    /**
+     * Get all dependencies added via the added-dependencies maven plugin parameter
+     * or an empty list.
+     */
+    List<J2clArtifactCoords> addedDependencies(final J2clArtifactCoords coords) {
+        return this.addedDependencies.getOrDefault(coords, Lists.empty());
+    }
+
+    /**
+     * Added to each discovered dependency as they are discovered.
+     */
+    private final Map<J2clArtifactCoords, List<J2clArtifactCoords>> addedDependencies;
 
     final J2clClasspathScope scope;
     final CompilationLevel level;


### PR DESCRIPTION
- Supports adding missing but required dependencies such as jsinterop-base
 missing com.vertispan.j2cl:gwt-internal-annotations:0.4-SNAPSHOT