### PR TITLE
J2clStepWorker subclass naming fix

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clArtifactCoords.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clArtifactCoords.java
@@ -70,7 +70,7 @@ final class J2clArtifactCoords implements Comparable<J2clArtifactCoords> {
     }
 
     /**
-     * Used to form source coordinates so {@link J2ClStepWorkerUnpack} can fetch the accompany sources.jar for any dependency.
+     * Used to form source coordinates so {@link J2clStepWorkerUnpack} can fetch the accompany sources.jar for any dependency.
      */
     J2clArtifactCoords source() {
         return new J2clArtifactCoords(this.groupId,

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 /**
  * Runs all tests that are matched by `<tests>` as defined in the POM. The junit annotation processor will
- * create several files and {@link J2ClStepWorkerWebDriverUnitTestRunner} will prepare a HTML which will run all tests
+ * create several files and {@link J2clStepWorkerWebDriverUnitTestRunner} will prepare a HTML which will run all tests
  * and will be executed by webdriver.
  */
 @Mojo(name = "test", requiresDependencyResolution = ResolutionScope.TEST)

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker.java
@@ -20,23 +20,23 @@ package walkingkooka.j2cl.maven;
 @SuppressWarnings("StaticInitializerReferencesSubClass")
 abstract class J2clStepWorker {
 
-    final static J2clStepWorker HASH = J2ClStepWorkerHash.instance();
+    final static J2clStepWorker HASH = J2clStepWorkerHash.instance();
 
-    final static J2clStepWorker UNPACK = J2ClStepWorkerUnpack.instance();
+    final static J2clStepWorker UNPACK = J2clStepWorkerUnpack.instance();
 
-    final static J2clStepWorker COMPILE_SOURCE = J2ClStepWorkerJavacCompilerUnpackedSource.instance();
+    final static J2clStepWorker COMPILE_SOURCE = J2clStepWorkerJavacCompilerUnpackedSource.instance();
 
-    final static J2clStepWorker STRIP_GWT_INCOMPAT = J2ClStepWorkerGwtIncompatibleStripPreprocessor.instance();
+    final static J2clStepWorker STRIP_GWT_INCOMPAT = J2clStepWorkerGwtIncompatibleStripPreprocessor.instance();
 
-    final static J2clStepWorker COMPILE_STRIP_GWT_INCOMPAT = J2ClStepWorkerJavacCompilerGwtIncompatibleStrippedSource.instance();
+    final static J2clStepWorker COMPILE_STRIP_GWT_INCOMPAT = J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource.instance();
 
-    final static J2clStepWorker TRANSPILER = J2clStepWorkerJ2ClTranspiler.instance();
+    final static J2clStepWorker TRANSPILER = J2clStepWorkerJ2clTranspiler.instance();
 
-    final static J2clStepWorker CLOSURE = J2ClStepWorkerClosureCompiler.instance();
+    final static J2clStepWorker CLOSURE = J2clStepWorkerClosureCompiler.instance();
 
-    final static J2clStepWorker OUTPUT_ASSEMBLER = J2ClStepWorkerOutputAssembler.instance();
+    final static J2clStepWorker OUTPUT_ASSEMBLER = J2clStepWorkerOutputAssembler.instance();
 
-    final static J2clStepWorker JUNIT_WEBDRIVER_TESTS = J2ClStepWorkerWebDriverUnitTestRunner.instance();
+    final static J2clStepWorker JUNIT_WEBDRIVER_TESTS = J2clStepWorkerWebDriverUnitTestRunner.instance();
 
     J2clStepWorker() {
         super();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker2.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker2.java
@@ -22,12 +22,12 @@ import walkingkooka.text.CharSequences;
 /**
  * Any step that requires its working directory to be created before it can work.
  */
-abstract class J2ClStepWorker2 extends J2clStepWorker {
+abstract class J2clStepWorker2 extends J2clStepWorker {
 
     /**
      * Package private to limit sub classing.
      */
-    J2ClStepWorker2() {
+    J2clStepWorker2() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerClosureCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerClosureCompiler.java
@@ -24,16 +24,16 @@ import java.util.List;
 /**
  * Calls the closure compiler and assembles the final Javascript output.
  */
-final class J2ClStepWorkerClosureCompiler extends J2ClStepWorker2 {
+final class J2clStepWorkerClosureCompiler extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerClosureCompiler();
+        return new J2clStepWorkerClosureCompiler();
     }
 
-    private J2ClStepWorkerClosureCompiler() {
+    private J2clStepWorkerClosureCompiler() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerGwtIncompatibleStripPreprocessor.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerGwtIncompatibleStripPreprocessor.java
@@ -17,32 +17,33 @@
 
 package walkingkooka.j2cl.maven;
 
+import walkingkooka.collect.list.Lists;
+
 /**
  * Compiles the java source to the target {@link J2clStepDirectory#output()}.
  */
-final class J2ClStepWorkerJavacCompilerGwtIncompatibleStrippedSource extends J2ClStepWorkerJavacCompiler {
+final class J2clStepWorkerGwtIncompatibleStripPreprocessor extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerJavacCompilerGwtIncompatibleStrippedSource();
+        return new J2clStepWorkerGwtIncompatibleStripPreprocessor();
     }
 
     /**
      * Use singleton
      */
-    private J2ClStepWorkerJavacCompilerGwtIncompatibleStrippedSource() {
+    private J2clStepWorkerGwtIncompatibleStripPreprocessor() {
         super();
     }
 
     @Override
-    J2clStep sourcesStep() {
-        return J2clStep.GWT_INCOMPATIBLE_STRIP;
-    }
-
-    @Override
-    boolean shouldRunAnnotationProcessors() {
-        return false; // dont need to generate annotation processor classes again.
+    J2clStepResult execute1(final J2clDependency artifact,
+                            final J2clStepDirectory directory,
+                            final J2clLinePrinter logger) throws Exception {
+        return GwtIncompatibleStripPreprocessor.execute(Lists.of(artifact.step(J2clStep.COMPILE).output(), artifact.step(J2clStep.UNPACK).output()),
+                directory.output().emptyOrFail(),
+                logger);
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerHash.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerHash.java
@@ -36,19 +36,19 @@ import java.util.stream.Collectors;
 /**
  * Takes a {@link J2clDependency} and computes the hash for the files directly belonging to the artifact and then its dependencies.
  */
-final class J2ClStepWorkerHash extends J2clStepWorker {
+final class J2clStepWorkerHash extends J2clStepWorker {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerHash();
+        return new J2clStepWorkerHash();
     }
 
     /**
      * Use singleton
      */
-    private J2ClStepWorkerHash() {
+    private J2clStepWorkerHash() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJ2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJ2clTranspiler.java
@@ -24,16 +24,16 @@ import java.util.List;
 /**
  * Transpiles the stripped source into javascript equivalents.
  */
-final class J2clStepWorkerJ2ClTranspiler extends J2ClStepWorker2 {
+final class J2clStepWorkerJ2clTranspiler extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2clStepWorkerJ2ClTranspiler();
+        return new J2clStepWorkerJ2clTranspiler();
     }
 
-    private J2clStepWorkerJ2ClTranspiler() {
+    private J2clStepWorkerJ2clTranspiler() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
@@ -24,12 +24,12 @@ import java.util.List;
 /**
  * Compiles the java source from sources and the given target.
  */
-abstract class J2ClStepWorkerJavacCompiler extends J2ClStepWorker2 {
+abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
 
     /**
      * Package private to limit sub classing.
      */
-    J2ClStepWorkerJavacCompiler() {
+    J2clStepWorkerJavacCompiler() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource.java
@@ -18,31 +18,31 @@
 package walkingkooka.j2cl.maven;
 
 /**
- * Compiles the java source to the target {@link J2clStepDirectory#output()}, with annotation processors enabled.
+ * Compiles the java source to the target {@link J2clStepDirectory#output()}.
  */
-final class J2ClStepWorkerJavacCompilerUnpackedSource extends J2ClStepWorkerJavacCompiler {
+final class J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource extends J2clStepWorkerJavacCompiler {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerJavacCompilerUnpackedSource();
+        return new J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource();
     }
 
     /**
      * Use singleton
      */
-    private J2ClStepWorkerJavacCompilerUnpackedSource() {
+    private J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource() {
         super();
     }
 
     @Override
     J2clStep sourcesStep() {
-        return J2clStep.UNPACK;
+        return J2clStep.GWT_INCOMPATIBLE_STRIP;
     }
 
     @Override
     boolean shouldRunAnnotationProcessors() {
-        return true;
+        return false; // dont need to generate annotation processor classes again.
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerUnpackedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerUnpackedSource.java
@@ -17,33 +17,32 @@
 
 package walkingkooka.j2cl.maven;
 
-import walkingkooka.collect.list.Lists;
-
 /**
- * Compiles the java source to the target {@link J2clStepDirectory#output()}.
+ * Compiles the java source to the target {@link J2clStepDirectory#output()}, with annotation processors enabled.
  */
-final class J2ClStepWorkerGwtIncompatibleStripPreprocessor extends J2ClStepWorker2 {
+final class J2clStepWorkerJavacCompilerUnpackedSource extends J2clStepWorkerJavacCompiler {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerGwtIncompatibleStripPreprocessor();
+        return new J2clStepWorkerJavacCompilerUnpackedSource();
     }
 
     /**
      * Use singleton
      */
-    private J2ClStepWorkerGwtIncompatibleStripPreprocessor() {
+    private J2clStepWorkerJavacCompilerUnpackedSource() {
         super();
     }
 
     @Override
-    J2clStepResult execute1(final J2clDependency artifact,
-                            final J2clStepDirectory directory,
-                            final J2clLinePrinter logger) throws Exception {
-        return GwtIncompatibleStripPreprocessor.execute(Lists.of(artifact.step(J2clStep.COMPILE).output(), artifact.step(J2clStep.UNPACK).output()),
-                directory.output().emptyOrFail(),
-                logger);
+    J2clStep sourcesStep() {
+        return J2clStep.UNPACK;
+    }
+
+    @Override
+    boolean shouldRunAnnotationProcessors() {
+        return true;
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerOutputAssembler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerOutputAssembler.java
@@ -22,16 +22,16 @@ import java.util.Collection;
 /**
  * Calls the closure compiler and assembles the final Javascript output.
  */
-final class J2ClStepWorkerOutputAssembler extends J2ClStepWorker2 {
+final class J2clStepWorkerOutputAssembler extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerOutputAssembler();
+        return new J2clStepWorkerOutputAssembler();
     }
 
-    private J2ClStepWorkerOutputAssembler() {
+    private J2clStepWorkerOutputAssembler() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerUnpack.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerUnpack.java
@@ -17,31 +17,27 @@
 
 package walkingkooka.j2cl.maven;
 
-import walkingkooka.collect.set.Sets;
-import walkingkooka.naming.StringPath;
-
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Unpacks the source from the sources artifact (jar with sources) and if no java files are present tries
  * the binary (jar) to {@link J2clStepDirectory#output()}. If no java source files are present processing of this
  * artifact is aborted and no attempt will be made to transpile java to javascript.
  */
-final class J2ClStepWorkerUnpack extends J2ClStepWorker2 {
+final class J2clStepWorkerUnpack extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerUnpack();
+        return new J2clStepWorkerUnpack();
     }
 
     /**
      * Use singleton
      */
-    private J2ClStepWorkerUnpack() {
+    private J2clStepWorkerUnpack() {
         super();
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerWebDriverUnitTestRunner.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerWebDriverUnitTestRunner.java
@@ -35,16 +35,16 @@ import java.time.Duration;
  * Assumes that the closure compiler has completed successfully and then invokes web driver to execute the prepared
  * js file containing the tests.
  */
-final class J2ClStepWorkerWebDriverUnitTestRunner extends J2ClStepWorker2 {
+final class J2clStepWorkerWebDriverUnitTestRunner extends J2clStepWorker2 {
 
     /**
      * Singleton
      */
     static J2clStepWorker instance() {
-        return new J2ClStepWorkerWebDriverUnitTestRunner();
+        return new J2clStepWorkerWebDriverUnitTestRunner();
     }
 
-    private J2ClStepWorkerWebDriverUnitTestRunner() {
+    private J2clStepWorkerWebDriverUnitTestRunner() {
         super();
     }
 


### PR DESCRIPTION
- J2CL becomes J2cl, replace capital c with little c.