### PR TITLE
Hash dependencies archive files

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/HashBuilder.java
+++ b/src/main/java/walkingkooka/j2cl/maven/HashBuilder.java
@@ -19,7 +19,10 @@ package walkingkooka.j2cl.maven;
 
 import org.apache.commons.codec.binary.Hex;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -49,6 +52,10 @@ final class HashBuilder {
 
     HashBuilder append(final String text) {
         return this.append(text.getBytes(Charset.defaultCharset()));
+    }
+
+    HashBuilder append(final Path file) throws IOException {
+        return this.append(Files.readAllBytes(file));
     }
 
     HashBuilder append(final byte[] content) {

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerHash.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerHash.java
@@ -68,7 +68,7 @@ final class J2clStepWorkerHash extends J2clStepWorker {
 
     private void hashDependencies(final J2clDependency artifact,
                                   final HashBuilder hash,
-                                  final J2clLinePrinter logger) {
+                                  final J2clLinePrinter logger) throws IOException {
         final Set<J2clDependency> dependencies = artifact.dependencies(); // dependencies();
         logger.printLine(dependencies.size() + " Dependencies");
         logger.indent();
@@ -79,11 +79,7 @@ final class J2clStepWorkerHash extends J2clStepWorker {
             logger.printLine(dependency.toString());
             logger.indent();
             {
-                if(dependency.isProcessingRequired()) {
-                    hash.append(dependency.directory().toString());
-                } else {
-                    hash.append(dependency.toString());
-                }
+                hash.append(dependency.artifactFileOrFail().path());
             }
             logger.outdent();
         }
@@ -149,7 +145,7 @@ final class J2clStepWorkerHash extends J2clStepWorker {
             @Override
             public FileVisitResult visitFile(final Path path,
                                              final BasicFileAttributes basicFileAttributes) throws IOException {
-                hash.append(Files.readAllBytes(path));
+                hash.append(path);
                 return FileVisitResult.CONTINUE;
             }
 


### PR DESCRIPTION
- previously only the dependency coords and not the file(s) were hashed.