### PR TITLE
Excluded-dependencies support for optional classifiers.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -363,14 +363,15 @@ A Closure compiler argument containing one or more entry point(s).
 
 
 ## excluded-dependencies
-A list of artifacts (group-id colon artifact-id) that may appear as transitive dependencies that must be excluded from
-the build process. The sample below is useful when requiring gwt-user, which contains a combination of client/translatable
-and server/untranslatable packages/classes.
+A list of artifacts (group-id colon artifact-id colon version) or (group-id colon artifact-id colon classifier colon version)
+that may appear as transitive dependencies that must be excluded from the build process. The sample below is useful when
+requiring gwt-user, which contains a combination of client/translatable and server/untranslatable packages/classes.
 
 ```xml
 <excluded-dependencies>
-    <param>javax.servlet:javax.servlet-api</param>
-    <param>javax.validation:validation-api</param>
+    <param>javax.servlet:javax.servlet-api:1.0</param>
+    <param>javax.validation:validation-api:1.0</param>
+    <param>group1:artifact2:classifier3:version4</param>
 </excluded-dependencies>
 ```
 

--- a/src/it/gwt-timer-j2cl-tests-several/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests-several/pom.xml
@@ -270,7 +270,7 @@
                             <externs/>
                             <formatting/>
                             <language-out>ECMASCRIPT_2016</language-out>
-                            <thread-pool-size>1</thread-pool-size>
+                            <thread-pool-size>0</thread-pool-size>
 
                             <added-dependencies>
                                 <param>
@@ -291,6 +291,7 @@
                                 <param>com.vertispan.j2cl:junit-emul:0.3-SNAPSHOT</param>
                             </classpath-required>
                             <excluded-dependencies>
+                                <param>com.google.elemental2:elemental2-dom:sources:1.0.0-RC1</param>
                                 <param>com.google.gwt:gwt-user:2.8.2</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:1.0.2</param>
                                 <param>javax.servlet:javax.servlet-api:3.1.0</param>

--- a/src/it/gwt-timer-j2cl-tests/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests/pom.xml
@@ -271,7 +271,7 @@
                             <externs/>
                             <formatting/>
                             <language-out>ECMASCRIPT_2016</language-out>
-                            <thread-pool-size>1</thread-pool-size>
+                            <thread-pool-size>0</thread-pool-size>
 
                             <added-dependencies>
                                 <param>
@@ -293,6 +293,7 @@
                                 <param>com.vertispan.j2cl:junit-emul:0.3-SNAPSHOT</param>
                             </classpath-required>
                             <excluded-dependencies>
+                                <param>com.google.elemental2:elemental2-dom:sources:1.0.0-RC1</param>
                                 <param>com.google.gwt:gwt-user:2.8.2</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:1.0.2</param>
                                 <param>javax.servlet:javax.servlet-api:3.1.0</param>


### PR DESCRIPTION
- it tests: gwt-timer-j2cl-tests, gwt-timer-j2cl-tests-many Fixed & thread-pool-size=0
- Closes #149 