### PR TITLE
Missing slash for root paths FIX

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clLinePrinter.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clLinePrinter.java
@@ -21,7 +21,6 @@ import com.google.j2cl.common.FrontendUtils.FileInfo;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.naming.StringName;
 import walkingkooka.naming.StringPath;
-import walkingkooka.text.CharSequences;
 import walkingkooka.text.LineEnding;
 import walkingkooka.text.pretty.Table;
 import walkingkooka.text.pretty.TextPretty;
@@ -102,6 +101,8 @@ final class J2clLinePrinter {
                     J2clLinePrinter.this.printLine(path);
                     printer.indent();
                 }
+
+                this.level++;
             }
 
             @Override
@@ -110,11 +111,20 @@ final class J2clLinePrinter {
                 if (false == path.isEmpty()) {
                     printer.outdent();
                 }
+
+                this.level--;
             }
 
             private String toPath(final List<StringName> names) {
-                return toPath(names, StringPath.SEPARATOR);
+                final String path = toPath(names, StringPath.SEPARATOR);
+                return 0 == this.level ?
+                        "/" + path :
+                        path;
             }
+
+            // https://github.com/mP1/j2cl-maven-plugin/issues/258
+            // helpers identify a root path so a leading slash can be added.
+            private int level;
 
             @Override
             public void children(final Set<StringPath> paths, final IndentingPrinter printer) {

--- a/src/test/java/walkingkooka/j2cl/maven/J2clLinePrinterTest.java
+++ b/src/test/java/walkingkooka/j2cl/maven/J2clLinePrinterTest.java
@@ -158,7 +158,7 @@ public final class J2clLinePrinterTest implements ClassTesting2<J2clLinePrinter>
         printer.printIndented("label1", List.of(path("/path/to")));
 
         this.check("label1\n" +
-                        "    path\n" +
+                        "    /path\n" +
                         "      to\n" +
                         "  1 file(s)",
                 b);
@@ -172,7 +172,7 @@ public final class J2clLinePrinterTest implements ClassTesting2<J2clLinePrinter>
         printer.printIndented("label1", List.of(path("/path/to"), path("/path/to2")));
 
         this.check("label1\n" +
-                        "    path\n" +
+                        "    /path\n" +
                         "      to                                                           to2\n" +
                         "  2 file(s)",
                 b);


### PR DESCRIPTION
- Closes #258

```
Bootstrap
    /Users/miroslav/repos-github/j2cl-maven-plugin/target/it-repo/com/vertispan/j2cl/javac-bootstrap-classpath/0.7-SNAPSHOT
      javac-bootstrap-classpath-0.7-SNAPSHOT.jar
  1 file(s)
Classpath(s)
    /Users/miroslav/repos-github/j2cl-maven-plugin/target/it-repo
      com
        google/jsinterop/jsinterop-annotations/2.0.0
          jsinterop-annotations-2.0.0.jar
        vertispan
          j2cl
            bootstrap/0.7-SNAPSHOT
              bootstrap-0.7-SNAPSHOT-jszip.zip
            gwt-internal-annotations/0.7-SNAPSHOT
              gwt-internal-annotations-0.7-SNAPSHOT.jar
            jre/0.7-SNAPSHOT
              jre-0.7-SNAPSHOT-jszip.zip                                   jre-0.7-SNAPSHOT.jar
          jsinterop/base/1.0.0-SNAPSHOT
            base-1.0.0-SNAPSHOT.jar
      walkingkooka/j2cl-uber/1.0-SNAPSHOT
        j2cl-uber-1.0-SNAPSHOT.jar
  7 file(s)
New java file(s)
    /Users/miroslav/repos-github/j2cl-maven-plugin/target/it-tests/example-es5/target/walkingkooka-j2cl-maven-plugin-cache/walkingkooka-example-es5-war-1.0-a4cfe626fb6dc6cc5f6bcada97dd2af09466e96e/1-unpack/output/example/es5lib
      HelloWorld.java
```