### PR TITLE
replaced google/vertispan with repackaged j2cl module artifacts

### DIFF
--- a/samples/sample.junit.pom.xml
+++ b/samples/sample.junit.pom.xml
@@ -159,29 +159,21 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>
-                                    com.vertispan.jsinterop:base:1.0.0-SNAPSHOT=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}
-                                </param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:junit-emul:${j2cl.version}</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </classpath-required>
                             <ignored>
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:${j2cl.version}</param>
-                                <param>com.vertispan.j2cl:junit-emul:${j2cl.version}</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </ignored>
                             <javascript-source-required>
-                                <param>com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:${j2cl.version}</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-javascript:*</param>
                             </javascript-source-required>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                             <skip-tests>false</skip-tests>
                             <tests>

--- a/samples/sample.pom.xml
+++ b/samples/sample.pom.xml
@@ -143,19 +143,13 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:jar:*=com.vertispan.j2cl:gwt-internal-annotations:*</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:jar:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
-                            <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
-                                <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </replaced-dependencies>
+                            <replaced-dependencies/>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/example-dependency-exclusion/example-dependency-exclusions-app/pom.xml
+++ b/src/it/example-dependency-exclusion/example-dependency-exclusions-app/pom.xml
@@ -96,18 +96,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-es5/pom.xml
+++ b/src/it/example-es5/pom.xml
@@ -91,18 +91,15 @@
                             <language-out>ECMASCRIPT5</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-formatting/pom.xml
+++ b/src/it/example-formatting/pom.xml
@@ -55,13 +55,6 @@
             <artifactId>j2cl-uber</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-uber-test</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -93,18 +86,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                          </configuration>
                     </execution>

--- a/src/it/example-hello-world-reactor/example-hello-world-reactor-app/pom.xml
+++ b/src/it/example-hello-world-reactor/example-hello-world-reactor-app/pom.xml
@@ -89,18 +89,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-hello-world-single/pom.xml
+++ b/src/it/example-hello-world-single/pom.xml
@@ -55,13 +55,6 @@
             <artifactId>j2cl-uber</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-uber-test</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -93,18 +86,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-ignore-file/pom.xml
+++ b/src/it/example-ignore-file/pom.xml
@@ -55,13 +55,6 @@
             <artifactId>j2cl-uber</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-uber-test</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -91,18 +84,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-shade/pom.xml
+++ b/src/it/example-shade/pom.xml
@@ -28,13 +28,6 @@
             <artifactId>j2cl-uber</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-uber-test</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -64,18 +57,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-shaded-jre-class-test/pom.xml
+++ b/src/it/example-shaded-jre-class-test/pom.xml
@@ -157,28 +157,21 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>
-                                    com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}
-                                </param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </classpath-required>
                             <ignored>
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </ignored>
                             <javascript-source-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-javascript:*</param>
                             </javascript-source-required>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                             <skip-tests>false</skip-tests>
                             <tests>

--- a/src/it/example-super-source/pom.xml
+++ b/src/it/example-super-source/pom.xml
@@ -86,18 +86,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
                             <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>

--- a/src/it/example-test/pom.xml
+++ b/src/it/example-test/pom.xml
@@ -87,7 +87,6 @@
             <groupId>walkingkooka</groupId>
             <artifactId>j2cl-uber-test</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -165,29 +164,23 @@
                             <externs/>
                             <formatting/>
                             <language-out>ECMASCRIPT_2016</language-out>
-                            <thread-pool-size>0</thread-pool-size>
+                            <thread-pool-size>1</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>
-                                    com.vertispan.jsinterop:base:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}
-                                </param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </classpath-required>
                             <ignored>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </ignored>
                             <javascript-source-required>
-                                <param>com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-javascript:*</param>
                             </javascript-source-required>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                             <skip-tests>false</skip-tests>
                             <tests>

--- a/src/it/gwt-timer-j2cl-tests-several/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests-several/pom.xml
@@ -107,14 +107,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.elemental2</groupId>
-            <artifactId>elemental2-dom</artifactId>
-            <type>jar</type>
-            <version>1.0.0-RC1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.jsinterop</groupId>
             <artifactId>jsinterop-annotations</artifactId>
             <version>2.0.0</version>
@@ -134,6 +126,12 @@
                 <groupId>com.vertispan.jsinterop</groupId>
                 <artifactId>base</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.jsinterop</groupId>
+                <artifactId>jsinterop-annotations</artifactId>
+                <version>2.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -206,28 +204,24 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:jar:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </classpath-required>
                             <ignored>
-                                <param>com.google.elemental2:elemental2-dom:sources:*</param>
-
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>com.google.elemental2:elemental2-dom:jar:sources:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </ignored>
                             <javascript-source-required>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-javascript:*</param>
                             </javascript-source-required>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
+
                             <skip-tests>false</skip-tests>
                             <tests>
                                 <test>org.gwtproject.timer.client.TimerJ2clTest</test>

--- a/src/it/gwt-timer-j2cl-tests/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests/pom.xml
@@ -105,27 +105,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.elemental2</groupId>
-            <artifactId>elemental2-dom</artifactId>
-            <type>jar</type>
-            <version>1.0.0-RC1</version>
-            <scope>test</scope>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.elemental2</groupId>
-                    <artifactId>elemental2-dom</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.jsinterop</groupId>
-            <artifactId>jsinterop-annotations</artifactId>
-            <version>2.0.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>walkingkooka</groupId>
             <artifactId>j2cl-uber-test</artifactId>
             <version>1.0-SNAPSHOT</version>
@@ -217,27 +196,24 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:jar:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </classpath-required>
                             <ignored>
-                                <param>com.google.elemental2:elemental2-dom:sources:*</param>
-
-                                <!-- junit -->
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
-                                <param>com.vertispan.j2cl:junit-emul:*</param>
+                                <param>com.google.elemental2:elemental2-dom:jar:sources:*</param>
+                                <param>walkingkooka:j2cl-junit-java:*</param>
                             </ignored>
                             <javascript-source-required>
-                                <param>com.vertispan.j2cl:closure-test:zip:jszip:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
+                                <param>walkingkooka:j2cl-junit-javascript:*</param>
                             </javascript-source-required>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
+
                             <skip-tests>false</skip-tests>
                             <tests>
                                 <test>org.gwtproject.timer.client.TimerJ2clTest</test>

--- a/src/it/vertispan-connected/pom.xml
+++ b/src/it/vertispan-connected/pom.xml
@@ -141,20 +141,15 @@
                             <language-out>ECMASCRIPT_2016</language-out>
                             <thread-pool-size>0</thread-pool-size>
 
-                            <added-dependencies>
-                                <param>com.vertispan.jsinterop:base:jar:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
-                            </added-dependencies>
+                            <added-dependencies/>
                             <classpath-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
+                                <param>walkingkooka:jsinterop-base:*</param>
                             </classpath-required>
                             <ignored/>
-                            <javascript-source-required>
-                                <param>com.vertispan.jsinterop:base:*</param>
-                            </javascript-source-required>
+                            <javascript-source-required/>
                             <replaced-dependencies>
-                                <param>com.google.jsinterop:base:*=com.vertispan.jsinterop:base:1.0.0-SNAPSHOT</param>
+                                <param>com.google.jsinterop:base:*=walkingkooka:jsinterop-base:1.0-SNAPSHOT</param>
                                 <param>com.google.jsinterop:jsinterop-annotations:*=com.google.jsinterop:jsinterop-annotations:2.0.0</param>
-                                <param>com.vertispan.j2cl:gwt-internal-annotations:*=com.vertispan.j2cl:gwt-internal-annotations:${j2cl.version}</param>
                             </replaced-dependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- all walkingkooka:j2c-* artifacts now have correct dependencies.