### PR TITLE
0b1b2ebf6eec0bbac91c691ec3c25f56ad0da638 walkingkooka 20200421

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
@@ -105,7 +105,7 @@ final class JavacCompiler {
     private static String toClasspathStringList(final List<J2clPath> entries) {
         return entries.stream()
                 .map(J2clPath::toString)
-                .collect(Collectors.joining(SystemProperty.JAVA_CLASS_PATH_SEPARATOR.value()));
+                .collect(Collectors.joining(SystemProperty.JAVA_CLASS_PATH_SEPARATOR.requiredPropertyValue()));
     }
 
     /**


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka/pull/2433
- SystemProperty.propertyValue returns Optional<String> was String

- Wrong SystemProperty getter used but luckily never caused problem due to bootstrap always being a single value.