### PR TITLE
Flat path collection option support

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/GwtIncompatibleStripPreprocessor.java
+++ b/src/main/java/walkingkooka/j2cl/maven/GwtIncompatibleStripPreprocessor.java
@@ -66,7 +66,7 @@ final class GwtIncompatibleStripPreprocessor {
             result = processStripAnnotationsFiles(javaFiles, output, logger);
 
             copyJavascriptFiles(sourceRoots, output, logger);
-            logger.printIndented("Output file(s)", output.gatherFiles(J2clPath.ALL_FILES));
+            logger.printIndented("Output file(s)", output.gatherFiles(J2clPath.ALL_FILES), J2clLinePrinterFormat.TREE);
 
         } else {
             logger.printIndentedLine("No files found");
@@ -119,7 +119,7 @@ final class GwtIncompatibleStripPreprocessor {
         {
             logger.indent();
             {
-                logger.printIndentedFileInfo("Source(s)", javaFilesInput);
+                logger.printIndentedFileInfo("Source(s)", javaFilesInput, J2clLinePrinterFormat.TREE);
                 logger.printIndented("Output", output);
 
                 final Problems problems = new Problems();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clLinePrinterFormat.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clLinePrinterFormat.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.j2cl.maven;
+
+import walkingkooka.naming.StringPath;
+import walkingkooka.text.printer.IndentingPrinter;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+// maven-plugin-plugin fails build because of enum method with generics, while scanning classpath for javadoc annotations.
+enum J2clLinePrinterFormat {
+    // Useful for printing a list of files where order is important such as a classpath.
+    FLAT {
+//        @Override
+//        <T> void print(final Collection<T> paths,
+//                       final Function<T, StringPath> toStringPath,
+//                       final IndentingPrinter printer) {
+//            J2clLinePrinter.printFlat(paths, toStringPath, printer);
+//        }
+    },
+
+    // Useful for printing a tree of files which will appear lexicagraphically(???) sorted
+    TREE {
+//        @Override
+//        <T> void print(final Collection<T> paths,
+//                       final Function<T, StringPath> toStringPath,
+//                       final IndentingPrinter printer) {
+//            J2clLinePrinter.printTree(paths, toStringPath, printer);
+//        }
+    };
+
+//    abstract <T> void print(final Collection<T> paths,
+//                            final Function<T, StringPath> toStringPath,
+//                            final IndentingPrinter printer);
+}

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -169,11 +169,11 @@ final class J2clPath implements Comparable<J2clPath> {
             }
             logger.outdent();
         } else {
-            logger.printIndented("Copied", copied);
+            logger.printIndented("Copied", copied, J2clLinePrinterFormat.TREE);
         }
 
         if (false == skipped.isEmpty()) {
-            logger.printIndented("Skipped", skipped);
+            logger.printIndented("Skipped", skipped, J2clLinePrinterFormat.TREE);
         }
 
         return copied;
@@ -248,7 +248,7 @@ final class J2clPath implements Comparable<J2clPath> {
             Files.copy(filePath, copyTarget, StandardCopyOption.REPLACE_EXISTING);
         }
 
-        logger.printIndented("Extracting", files);
+        logger.printIndented("Extracting", files, J2clLinePrinterFormat.TREE);
     }
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerUnpack.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerUnpack.java
@@ -85,7 +85,7 @@ final class J2clStepWorkerUnpack extends J2clStepWorker2 {
         boolean filesFound = false;
 
         final List<J2clPath> sourceRoots = artifact.sourcesRoot();
-        logger.printIndented("Source root(s)", sourceRoots);
+        logger.printIndented("Source root(s)", sourceRoots, J2clLinePrinterFormat.TREE);
 
         logger.printLine("Unpacking...");
         logger.indent();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clTranspiler.java
@@ -65,10 +65,10 @@ final class J2clTranspiler {
             logger.printLine("Parameters");
             logger.indent();
             {
-                logger.printIndented("Classpath(s)", classpath);
-                logger.printIndented("*.java Source(s)", javaInput);
-                logger.printIndented("*.native.js source(s)", nativeJsInput);
-                logger.printIndented("*.js source(s)", jsInput);
+                logger.printIndented("Classpath(s)", classpath, J2clLinePrinterFormat.FLAT);
+                logger.printIndented("*.java Source(s)", javaInput, J2clLinePrinterFormat.TREE);
+                logger.printIndented("*.native.js source(s)", nativeJsInput, J2clLinePrinterFormat.TREE);
+                logger.printIndented("*.js source(s)", jsInput, J2clLinePrinterFormat.TREE);
                 logger.printIndented("Output", output);
             }
             logger.outdent();
@@ -110,7 +110,9 @@ final class J2clTranspiler {
                     }
                     logger.outdent();
 
-                    logger.printIndented("Output file(s) after copy", output.gatherFiles(J2clPath.ALL_FILES));
+                    logger.printIndented("Output file(s) after copy",
+                        output.gatherFiles(J2clPath.ALL_FILES),
+                        J2clLinePrinterFormat.TREE);
                 }
             }
         }

--- a/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
@@ -61,9 +61,9 @@ final class JavacCompiler {
             logger.printLine("Parameters");
             logger.indent();
             {
-                logger.printIndented("Bootstrap", bootstrap);
-                logger.printIndented("Classpath(s)", classpath);
-                logger.printIndented("New java file(s)", newSourceFiles); // printLine full paths here might be mixed sources...
+                logger.printIndented("Bootstrap", bootstrap, J2clLinePrinterFormat.FLAT);
+                logger.printIndented("Classpath(s)", classpath, J2clLinePrinterFormat.FLAT);
+                logger.printIndented("New java file(s)", newSourceFiles, J2clLinePrinterFormat.TREE); // order should not be important so tree
                 logger.printIndented("Output", newClassFilesOutput);
                 logger.printIndentedString("Option(s)", options);
             }

--- a/src/test/java/walkingkooka/j2cl/maven/J2clLinePrinterTest.java
+++ b/src/test/java/walkingkooka/j2cl/maven/J2clLinePrinterTest.java
@@ -151,11 +151,26 @@ public final class J2clLinePrinterTest implements ClassTesting2<J2clLinePrinter>
     }
 
     @Test
-    public void testPrintIndentedPathCollection() {
+    public void testPrintIndentedPathCollectionFlat() {
         final StringBuilder b = new StringBuilder();
         final J2clLinePrinter printer = this.printer2(b);
 
-        printer.printIndented("label1", List.of(path("/path/to")));
+        printer.printIndented("label1", List.of(path("/path/2"), path("/path/1"), path("/path/3")), J2clLinePrinterFormat.FLAT);
+
+        this.check("label1\n" +
+                        "    /path/2<\n" +
+                        "    /path/1<\n" +
+                        "    /path/3<\n" +
+                        "  3 file(s)",
+                b);
+    }
+
+    @Test
+    public void testPrintIndentedPathCollectionTree() {
+        final StringBuilder b = new StringBuilder();
+        final J2clLinePrinter printer = this.printer2(b);
+
+        printer.printIndented("label1", List.of(path("/path/to")), J2clLinePrinterFormat.TREE);
 
         this.check("label1\n" +
                         "    /path<\n" +
@@ -165,11 +180,11 @@ public final class J2clLinePrinterTest implements ClassTesting2<J2clLinePrinter>
     }
 
     @Test
-    public void testPrintIndentedPathCollection2() {
+    public void testPrintIndentedPathCollectionTree2() {
         final StringBuilder b = new StringBuilder();
         final J2clLinePrinter printer = this.printer2(b);
 
-        printer.printIndented("label1", List.of(path("/path/to"), path("/path/to2")));
+        printer.printIndented("label1", List.of(path("/path/to"), path("/path/to2")), J2clLinePrinterFormat.TREE);
 
         this.check("label1\n" +
                         "    /path<\n" +


### PR DESCRIPTION
- Intended where order is important such as classpaths
- mavenpluginplugin fails on J2clLinePrinterFormat an enum with methods holding type parameters,
  using a switch to simulate.