### PR TITLE
javac transpiler closure compiler path ignored filtering changes

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/ClosureCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/ClosureCompiler.java
@@ -120,6 +120,8 @@ class ClosureCompiler {
 
             success = false;
         } else {
+            logger.printIndented("Output", output);
+
             final J2clPath initialScriptFilenamePath = output.append(initialScriptFilename);
 
             final Map<String, Collection<String>> arguments = prepareArguments(compilationLevel,

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker2.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorker2.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.j2cl.maven;
 
+import java.util.Set;
+
 /**
  * Any step that requires its working directory to be created before it can work.
  */
@@ -93,4 +95,10 @@ abstract class J2clStepWorker2 extends J2clStepWorker {
     abstract J2clStepResult execute1(final J2clDependency artifact,
                                      final J2clStepDirectory directory,
                                      final J2clLinePrinter logger) throws Exception;
+
+    static void addIfAbsent(final J2clPath ifAbsent, final Set<J2clPath> target) {
+        if (false == target.contains(ifAbsent)) {
+            target.add(ifAbsent);
+        }
+    }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJ2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJ2clTranspiler.java
@@ -17,8 +17,10 @@
 
 package walkingkooka.j2cl.maven;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import walkingkooka.collect.set.Sets;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Transpiles the stripped source into javascript equivalents.
@@ -40,25 +42,12 @@ final class J2clStepWorkerJ2clTranspiler extends J2clStepWorker2 {
     final J2clStepResult execute1(final J2clDependency artifact,
                                   final J2clStepDirectory directory,
                                   final J2clLinePrinter logger) throws Exception {
-        final J2clPath sourceRoot;
-
-        if (artifact.isIgnored()) {
-            sourceRoot = artifact.step(J2clStep.UNPACK).output();
-        } else {
-            sourceRoot = shadeOrCompileGwtIncompatibleStripped(artifact, J2clStep.SHADE_JAVA_SOURCE, J2clStep.GWT_INCOMPATIBLE_STRIP);
-        }
-
         logger.printLine("Preparing...");
+
+        final J2clPath sourceRoot = this.sourceRoot(artifact);
         logger.printIndented("Source path(s)", sourceRoot);
 
-        final List<J2clPath> classpath = artifact.dependencies()
-                .stream()
-                .filter(d -> false == d.isAnnotationProcessor())
-                .map(d -> d.isIgnored() ?
-                        d.artifactFileOrFail() :
-                        shadeOrCompileGwtIncompatibleStripped(d, J2clStep.SHADE_CLASS_FILES, J2clStep.COMPILE_GWT_INCOMPATIBLE_STRIPPED))
-                .flatMap(d -> d.exists().stream())
-                .collect(Collectors.toList());
+        final Set<J2clPath> classpath = this.classpath(artifact);
 
         return J2clTranspiler.execute(classpath,
                 sourceRoot,
@@ -68,15 +57,84 @@ final class J2clStepWorkerJ2clTranspiler extends J2clStepWorker2 {
                 J2clStepResult.FAILED;
     }
 
-    /**
-     * Tries the $first/output and if that is absent tries $second/output.
-     */
-    private static J2clPath shadeOrCompileGwtIncompatibleStripped(final J2clDependency dependency,
-                                                                  final J2clStep tryFirst,
-                                                                  final J2clStep second) {
-        return dependency.step(tryFirst)
+    private J2clPath sourceRoot(final J2clDependency artifact) {
+        final J2clStep first = J2clStep.SHADE_JAVA_SOURCE;
+        final J2clStep second = J2clStep.GWT_INCOMPATIBLE_STRIP;
+        final J2clStep third = J2clStep.UNPACK;
+
+        final J2clPath sourceRoot;
+
+        final Optional<J2clPath> shaded = output(artifact, first);
+        if (shaded.isPresent()) {
+            sourceRoot = shaded.get();
+        } else {
+            final Optional<J2clPath> stripped = output(artifact, second);
+            if (stripped.isPresent()) {
+                sourceRoot = stripped.get();
+            } else {
+                final Optional<J2clPath> unpack = output(artifact, third);
+                if (unpack.isPresent()) {
+                    sourceRoot = unpack.get();
+                } else {
+                    throw new IllegalStateException("Missing " + first + ", " + second + ", " + third + " output for " + artifact);
+                }
+            }
+        }
+
+        return sourceRoot;
+    }
+
+    private Set<J2clPath> classpath(final J2clDependency artifact) {
+        final Set<J2clPath> classpath = Sets.ordered();
+
+        // only transpile if class required incl annotations, but not ignored or jre........................................
+
+        for (final J2clDependency dependency : artifact.dependencies()) {
+            if (dependency.isAnnotationClassFiles()) {
+                addIfAbsent(dependency.artifactFileOrFail(), classpath);
+                continue;
+            }
+
+            if (dependency.isAnnotationProcessor()) {
+                continue;
+            }
+
+            if (dependency.isIgnored()) {
+                continue;
+            }
+
+            if (dependency.isJreBootstrapClassFiles()) {
+                addIfAbsent(dependency.artifactFileOrFail(), classpath);
+                continue;
+            }
+
+            if (dependency.isJreClassFiles()) {
+                addIfAbsent(dependency.artifactFileOrFail(), classpath);
+                continue;
+            }
+
+            if (dependency.isClasspathRequired()) {
+                final Optional<J2clPath> shadeClassFiles = output(dependency, J2clStep.SHADE_CLASS_FILES);
+                if (shadeClassFiles.isPresent()) {
+                    addIfAbsent(shadeClassFiles.get(), classpath);
+                    continue;
+                }
+                final Optional<J2clPath> compileGwtIncompatibleStripped = output(dependency, J2clStep.COMPILE_GWT_INCOMPATIBLE_STRIPPED);
+                if (compileGwtIncompatibleStripped.isPresent()) {
+                    addIfAbsent(compileGwtIncompatibleStripped.get(), classpath);
+                    continue;
+                }
+            }
+
+            // shouldnt happen
+        }
+
+        return classpath;
+    }
+
+    private static Optional<J2clPath> output(final J2clDependency dependency, final J2clStep step) {
+        return dependency.step(step)
                 .output()
-                .exists()
-                .orElseGet(() -> dependency.step(second).output());
+                .exists();
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
@@ -58,8 +58,8 @@ abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
                 final J2clStep compiledStep = this.compiledStep();
 
                 for (final J2clDependency dependency : artifact.dependencies()) {
-                    if (dependency.isJreBootstrapClassFiles()) {
-                        addIfAbsent(dependency.artifactFileOrFail(), bootstrap);
+                    if (dependency.isAnnotationClassFiles()) {
+                        addIfAbsent(dependency.artifactFileOrFail(), classpath);
                         continue;
                     }
 
@@ -69,6 +69,24 @@ abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
                     }
 
                     if (dependency.isClasspathRequired()) {
+                        addIfAbsent(dependency.artifactFileOrFail(), classpath);
+                        continue;
+                    }
+
+                    if (dependency.isIgnored()) {
+                        continue;
+                    }
+
+                    if (dependency.isJavascriptSourceRequired()) {
+                        continue;
+                    }
+
+                    if (dependency.isJreBootstrapClassFiles()) {
+                        addIfAbsent(dependency.artifactFileOrFail(), bootstrap);
+                        continue;
+                    }
+
+                    if (dependency.isJreClassFiles()) {
                         addIfAbsent(dependency.artifactFileOrFail(), classpath);
                         continue;
                     }
@@ -104,12 +122,6 @@ abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
         }
 
         return result;
-    }
-
-    private static void addIfAbsent(final J2clPath ifAbsent, final Set<J2clPath> target) {
-        if (false == target.contains(ifAbsent)) {
-            target.add(ifAbsent);
-        }
     }
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/J2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clTranspiler.java
@@ -24,12 +24,13 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.text.CharSequences;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 final class J2clTranspiler {
 
-    static boolean execute(final List<J2clPath> classpath,
+    static boolean execute(final Collection<J2clPath> classpath,
                            final J2clPath sourcePath,
                            final J2clPath output,
                            final J2clLinePrinter logger) throws IOException {


### PR DESCRIPTION
- Ignored dependencies are never placed on any path (cp or js).
- javac, transpiler, closure compiler now include numerous filtering tests.
- Closes #362 