### PR TITLE
Shaded class transforming fix.

### DIFF
--- a/src/it/junit-test-jre-class-replaced-shaded/src/main/java/test/javautil/Locale.java
+++ b/src/it/junit-test-jre-class-replaced-shaded/src/main/java/test/javautil/Locale.java
@@ -21,8 +21,12 @@ public class Locale {
 
     public final static Locale ROOT = new Locale();
 
+    public String getCountry() {
+        return "getCountry.Shaded";
+    }
+
     @Override
     public String toString() {
-        return "Shaded";
+        return "toString.Shaded";
     }
 }

--- a/src/it/junit-test-jre-class-replaced-shaded/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test-jre-class-replaced-shaded/src/test/java/test/JunitTest.java
@@ -23,7 +23,12 @@ import org.junit.Test;
 public class JunitTest {
 
     @Test
-    public void testJreJavaUtilLocaleWasShaded() {
-        Assert.assertEquals("Shaded", java.util.Locale.ROOT.toString());
+    public void testJreJavaUtilLocaleGetCountryWasShaded() {
+        Assert.assertEquals("getCountry.Shaded", java.util.Locale.ROOT.getCountry());
+    }
+
+    @Test
+    public void testJreJavaUtilLocaleToStringWasShaded() {
+        Assert.assertEquals("toString.Shaded", java.util.Locale.ROOT.toString());
     }
 }

--- a/src/it/junit-test-jre-class-replaced-shaded2/dependency/src/main/java/test/javautil/Locale.java
+++ b/src/it/junit-test-jre-class-replaced-shaded2/dependency/src/main/java/test/javautil/Locale.java
@@ -21,8 +21,12 @@ public class Locale {
 
     public final static Locale ROOT = new Locale();
 
+    public String getCountry() {
+        return "getCountry.Shaded";
+    }
+
     @Override
     public String toString() {
-        return "Shaded";
+        return "toString.Shaded";
     }
 }

--- a/src/it/junit-test-jre-class-replaced-shaded2/test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test-jre-class-replaced-shaded2/test/src/test/java/test/JunitTest.java
@@ -23,8 +23,14 @@ import org.junit.Test;
 public class JunitTest {
 
     @Test
-    public void testJreJavaUtilLocaleWasShadedAndReplaced() {
-        // if the supplied JRE is used this will fail, if our replaced Locale is actually used this test will pass.
-        Assert.assertEquals("Shaded", java.util.Locale.ROOT.toString());
+    public void testJreJavaUtilLocaleGetCountry() {
+        // if shading failed this wont compile
+        Assert.assertEquals("getCountry.Shaded", java.util.Locale.ROOT.getCountry());
+    }
+
+    @Test
+    public void testJreJavaUtilLocaleToStringWasShadedAndReplaced() {
+        // if the supplied JRE Locale is used this will fail, if our replaced Locale is actually used this test will pass.
+        Assert.assertEquals("toString.Shaded", java.util.Locale.ROOT.toString());
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -63,16 +63,41 @@ final class J2clPath implements Comparable<J2clPath> {
      */
     static final Predicate<Path> ALL_FILES = Files::isRegularFile;
 
-    static final Predicate<Path> CLASS_FILES = fileEndsWith(".class");
-    static final Predicate<Path> JAVA_FILES = fileEndsWith(".java");
-    static final Predicate<Path> JAVASCRIPT_FILES = fileEndsWith(".js");
-    static final Predicate<Path> NATIVE_JAVASCRIPT_FILES = fileEndsWith(".native.js");
+    /**
+     * Matches paths with a class file extension.
+     */
+    static final Predicate<Path> CLASS_FILEEXTENSION = fileEndsWith(".class");
+
+    /**
+     * Matches existing class files.
+     */
+    static final Predicate<Path> CLASS_FILES = ALL_FILES.and(CLASS_FILEEXTENSION);
+
+    /**
+     * Matches paths with a java file extension.
+     */
+    static final Predicate<Path> JAVA_FILEEXTENSION = fileEndsWith(".java");
+
+    /**
+     * Matches existing java files.
+     */
+    static final Predicate<Path> JAVA_FILES = ALL_FILES.and(JAVA_FILEEXTENSION);
+
+    /**
+     * Matches existing js files.
+     */
+    static final Predicate<Path> JAVASCRIPT_FILES = ALL_FILES.and(fileEndsWith(".js"));
+
+    /**
+     * Matches existing native.js files.
+     */
+    static final Predicate<Path> NATIVE_JAVASCRIPT_FILES = ALL_FILES.and(fileEndsWith(".native.js"));
 
     /**
      * Matches all files that end with the given extension, assumes the extension includes a leading dot.
      */
     private static Predicate<Path> fileEndsWith(final String extension) {
-        return ALL_FILES.and((p) -> p.getFileName().toString().endsWith(extension));
+        return (p) -> p.getFileName().toString().endsWith(extension);
     }
 
     /**
@@ -83,7 +108,7 @@ final class J2clPath implements Comparable<J2clPath> {
     /**
      * Matches all files except for java source.
      */
-    static final Predicate<Path> ALL_FILES_EXCEPT_JAVA = ALL_FILES.and((p) -> false == p.getFileName().toString().endsWith(".java"));
+    static final Predicate<Path> ALL_FILES_EXCEPT_JAVA = ALL_FILES.and((p) -> ! JAVA_FILEEXTENSION.test(p));
 
     static List<File> toFiles(final Collection<J2clPath> paths) {
         return paths.stream().map(J2clPath::file).collect(Collectors.toList());

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShade.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShade.java
@@ -89,7 +89,8 @@ abstract class J2clStepWorkerShade extends J2clStepWorker2 {
                               final Map<String, String> shade,
                               final J2clPath output,
                               final J2clLinePrinter logger) throws Exception {
-        final Set<J2clPath> files = root.gatherFiles(this.fileFilter());
+        final Predicate<Path> filter = this.fileExtensionFilter();
+        final Set<J2clPath> files = root.gatherFiles(J2clPath.ALL_FILES.and(filter));
         final Set<J2clPath> nonShadedFiles = Sets.sorted();
         nonShadedFiles.addAll(files);
 
@@ -120,7 +121,7 @@ abstract class J2clStepWorkerShade extends J2clStepWorker2 {
                     shadeDirectory.copyFiles(shadedRoot,
                             shadedFiles,
                             (content, path) -> {
-                                return path.isJava() ?
+                                return filter.test(path.path()) ?
                                         shade(content, shade) :
                                         content;
                             },
@@ -149,7 +150,10 @@ abstract class J2clStepWorkerShade extends J2clStepWorker2 {
         logger.outdent();
     }
 
-    abstract Predicate<Path> fileFilter();
+    /**
+     * A filter that only tests the file extension. It does not test if the file actually exists.
+     */
+    abstract Predicate<Path> fileExtensionFilter();
 
     /**
      * Reads the file and shades the source text or class file type references.

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShadeClassFile.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShadeClassFile.java
@@ -52,8 +52,8 @@ final class J2clStepWorkerShadeClassFile extends J2clStepWorkerShade {
     }
 
     @Override
-    Predicate<Path> fileFilter() {
-        return J2clPath.CLASS_FILES;
+    Predicate<Path> fileExtensionFilter() {
+        return J2clPath.CLASS_FILEEXTENSION;
     }
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShadeJavaSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerShadeJavaSource.java
@@ -66,8 +66,8 @@ final class J2clStepWorkerShadeJavaSource extends J2clStepWorkerShade {
     }
 
     @Override
-    Predicate<Path> fileFilter() {
-        return J2clPath.JAVA_FILES;
+    Predicate<Path> fileExtensionFilter() {
+        return J2clPath.JAVA_FILEEXTENSION;
     }
 
     @Override


### PR DESCRIPTION
- Step base class handling both class and java source files was only matching *.java files.
- This bug meant that dependencies requiring shading silently failed.
- Improved tests to verify a emulated java.util.Locale is being shaded
- Added J2clPath filter constants.