### PR TITLE
javac steps bootstrap dependencies usage fix

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompiler.java
@@ -73,6 +73,11 @@ abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
                         continue;
                     }
 
+                    if (dependency.isJreBootstrapClassFiles()) {
+                        addIfAbsent(dependency.artifactFileOrFail(), bootstrap);
+                        continue;
+                    }
+
                     if (dependency.isClasspathRequired()) {
                         addIfAbsent(dependency.artifactFileOrFail(), classpath);
                         continue;
@@ -83,11 +88,6 @@ abstract class J2clStepWorkerJavacCompiler extends J2clStepWorker2 {
                     }
 
                     if (dependency.isJavascriptSourceRequired()) {
-                        continue;
-                    }
-
-                    if (dependency.isJreBootstrapClassFiles()) {
-                        addIfAbsent(dependency.artifactFileOrFail(), bootstrap);
                         continue;
                     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/JavacCompiler.java
@@ -43,6 +43,13 @@ final class JavacCompiler {
                            final Set<String>  javaCompilerArguments,
                            final boolean runAnnotationProcessors,
                            final J2clLinePrinter logger) throws Exception {
+        if (bootstrap.isEmpty()) {
+            throw new IllegalArgumentException("bootstrap must not be empty");
+        }
+        if (classpath.isEmpty()) {
+            throw new IllegalArgumentException("classpath must not be empty");
+        }
+
         // try and add options in alpha order...
         final List<String> options = Lists.array();
         options.add("-bootclasspath");


### PR DESCRIPTION
- JavacCompiler requires non empty bootstrap and classpath sets.