### PR TITLE
Fixed classpath entry selection when gwt-incompatible compiling

### DIFF
--- a/src/it/junit-test-dependency-gwt-incompatible/dependency/pom.xml
+++ b/src/it/junit-test-dependency-gwt-incompatible/dependency/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-maven-plugin-it-junit-test-dependency-gwt-incompatible-dependency</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-uber</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin}</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-Compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit-test-dependency-gwt-incompatible/dependency/src/main/java/dependency/Dependency.java
+++ b/src/it/junit-test-dependency-gwt-incompatible/dependency/src/main/java/dependency/Dependency.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2020 Miroslav Pokorny
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dependency;
+
+import javaemul.internal.annotations.GwtIncompatible;
+
+public abstract class Dependency {
+
+    public final String included() {
+        return "Included123";
+    }
+
+    @GwtIncompatible
+    public java.lang.reflect.Method gwtIncompatible1() {
+        return this.getClass().getMethods()[0];
+    }
+
+    @GwtIncompatible
+    public abstract java.lang.reflect.Method gwtIncompatible2();
+}

--- a/src/it/junit-test-dependency-gwt-incompatible/pom.xml
+++ b/src/it/junit-test-dependency-gwt-incompatible/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-maven-plugin-it-junit-test-dependency-gwt-incompatible</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>dependency</module>
+        <module>test</module>
+    </modules>
+
+</project>

--- a/src/it/junit-test-dependency-gwt-incompatible/test/pom.xml
+++ b/src/it/junit-test-dependency-gwt-incompatible/test/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-maven-plugin-it-junit-test-dependency-gwt-incompatible</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-uber-test</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-maven-plugin-it-junit-test-dependency-gwt-incompatible-dependency</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin}</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-Compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>j2cl-maven-plugin-it-junit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <browser-log-level>NONE</browser-log-level>
+                            <browsers>
+                                <param>CHROME</param>
+                            </browsers>
+                            <classpath-scope>test</classpath-scope>
+                            <compilation-level>ADVANCED</compilation-level>
+                            <defines>
+                                <gwt.cspCompatModeEnabled>true</gwt.cspCompatModeEnabled>
+                                <gwt.enableDebugId>true</gwt.enableDebugId>
+                                <gwt.strictCspTestingEnabled>true</gwt.strictCspTestingEnabled>
+                                <jre.checkedMode>DISABLED</jre.checkedMode>
+                                <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
+                                <jsinterop.checks>DISABLED</jsinterop.checks>
+                            </defines>
+                            <externs/>
+                            <formatting/>
+                            <java-compiler-arguments/>
+                            <language-out>ECMASCRIPT_2016</language-out>
+                            <thread-pool-size>0</thread-pool-size>
+
+                            <classpath-required/>
+                            <ignored-dependencies/>
+                            <javascript-source-required/>
+
+                            <skip-tests>false</skip-tests>
+                            <tests>
+                                <test>test.JunitTest</test>
+                            </tests>
+                            <test-timeout>20</test-timeout>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+</project>

--- a/src/it/junit-test-dependency-gwt-incompatible/test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test-dependency-gwt-incompatible/test/src/test/java/test/JunitTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020 Miroslav Pokorny
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import javaemul.internal.annotations.GwtIncompatible;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(JunitTest.class)
+public class JunitTest {
+
+    @Test
+    public void testGwtIncompatible() {
+        Assert.assertEquals("Included123", new dependency.Dependency() {
+            @GwtIncompatible
+            @Override
+            public java.lang.reflect.Method gwtIncompatible1() {
+                return this.getClass().getMethods()[0];
+            }
+
+            @GwtIncompatible
+            public java.lang.reflect.Method gwtIncompatible2() {
+                throw new UnsupportedOperationException();
+            }
+        }.included());
+    }
+}

--- a/src/main/java/walkingkooka/j2cl/maven/J2clDependency.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clDependency.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -1192,6 +1193,28 @@ final class J2clDependency implements Comparable<J2clDependency> {
      */
     J2clStepDirectory step(final J2clStep step) {
         return J2clStepDirectory.with(Paths.get(this.directory().toString(), step.directoryName()));
+    }
+
+    /**
+     * Tries to find the output directory for the given {@link J2clStep} stopping when one is found or returns
+     * the archive file for this dependency.
+     */
+    J2clPath stepSourcesOrArchiveFile(final List<J2clStep> steps) {
+        Objects.requireNonNull(steps, "steps");
+
+        J2clPath result = null;
+
+        final J2clPath directory = this.directory.get();
+        if (null != directory) {
+            result = steps.stream()
+                    .flatMap(s -> this.step(s).output().exists().stream())
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null != result ?
+                result :
+                this.artifactFileOrFail();
     }
 
     // maven ...........................................................................................................

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource.java
@@ -17,6 +17,10 @@
 
 package walkingkooka.j2cl.maven;
 
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
 /**
  * Compiles the java source to the target {@link J2clStepDirectory#output()}.
  */
@@ -42,13 +46,21 @@ final class J2clStepWorkerJavacCompilerGwtIncompatibleStrippedSource extends J2c
     }
 
     @Override
-    J2clStep compiledStep() {
-        return J2clStep.COMPILE_GWT_INCOMPATIBLE_STRIPPED;
+    List<J2clStep> compiledStep() {
+        return Lists.of(J2clStep.SHADE_CLASS_FILES, J2clStep.COMPILE_GWT_INCOMPATIBLE_STRIPPED);
     }
 
     @Override
     boolean shouldRunAnnotationProcessors() {
         return false; // dont need to generate annotation processor classes again.
+    }
+
+    /**
+     * Try adding the SHADED_CLASS_FILES then COMPILE_GWT_INCOMPATIBLE_STRIPPED then default to the original archive file.
+     */
+    @Override
+    J2clPath selectClassFiles(final J2clDependency dependency) {
+        return dependency.stepSourcesOrArchiveFile(this.compiledStep());
     }
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerUnpackedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepWorkerJavacCompilerUnpackedSource.java
@@ -17,9 +17,11 @@
 
 package walkingkooka.j2cl.maven;
 
+import walkingkooka.collect.list.Lists;
 import walkingkooka.text.CharSequences;
 
 import java.nio.file.Files;
+import java.util.List;
 
 /**
  * Compiles the java source to the target {@link J2clStepDirectory#output()}, with annotation processors enabled.
@@ -46,13 +48,21 @@ final class J2clStepWorkerJavacCompilerUnpackedSource extends J2clStepWorkerJava
     }
 
     @Override
-    J2clStep compiledStep() {
-        return J2clStep.COMPILE;
+    List<J2clStep> compiledStep() {
+        return Lists.of(J2clStep.COMPILE);
     }
 
     @Override
     boolean shouldRunAnnotationProcessors() {
         return true;
+    }
+
+    /**
+     * Always add the dependency jar file.
+     */
+    @Override
+    J2clPath selectClassFiles(final J2clDependency dependency) {
+        return dependency.artifactFileOrFail();
     }
 
     /**


### PR DESCRIPTION
- Changed behaviour of classpath when compiling each step: COMPILE_GWT_INCOMPATIBLE_STRIPPED,
 no longer uses dependency archives but rather compile-gwt-incompatible-stripped class files.