### PR TITLE
J2clPath.shadeFile made package private

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -375,7 +375,7 @@ public final class J2clPath implements Comparable<J2clPath> {
     /**
      * Builds a new path holding the shade mapping file.
      */
-    public J2clPath shadeFile() {
+    J2clPath shadeFile() {
         return this.append(SHADE_FILE);
     }
 


### PR DESCRIPTION
- Only required by J2clDependency shouldnt be public.