### PR TITLE
log sources & logging simplifications

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -175,8 +175,7 @@ public final class J2clPath implements Comparable<J2clPath> {
      */
     public Collection<J2clPath> copyFiles(final J2clPath src,
                                           final Collection<J2clPath> files,
-                                          final BiFunction<byte[], J2clPath, byte[]> contentTransformer,
-                                          final TreeLogger logger) throws IOException {
+                                          final BiFunction<byte[], J2clPath, byte[]> contentTransformer) throws IOException {
         final Path srcPath = src.path();
         final Path destPath = this.path();
 
@@ -190,13 +189,13 @@ public final class J2clPath implements Comparable<J2clPath> {
             Files.createDirectories(copyTarget.getParent());
 
             final J2clPath copyTargetPath = J2clPath.with(copyTarget);
-            Files.write(copyTarget,
-                    contentTransformer.apply(Files.readAllBytes(filePath), copyTargetPath));
+            Files.write(
+                    copyTarget,
+                    contentTransformer.apply(Files.readAllBytes(filePath), copyTargetPath)
+            );
 
             copied.add(copyTargetPath);
         }
-
-        logger.paths("", copied, TreeFormat.TREE);
 
         return copied;
     }
@@ -266,7 +265,7 @@ public final class J2clPath implements Comparable<J2clPath> {
             Files.copy(filePath, copyTarget, StandardCopyOption.REPLACE_EXISTING);
         }
 
-        logger.paths("Extracting", files, TreeFormat.TREE);
+        logger.paths("", files, TreeFormat.TREE);
     }
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
+++ b/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
@@ -85,7 +85,15 @@ final public class TreeLogger {
     public void path(final String label,
                      final J2clPath file) {
         this.line(label);
-        this.indentedLine(file.toString());
+        this.indentedLine(
+                file.toString()
+        );
+    }
+
+    public void path(final J2clPath file) {
+        this.line(
+                file.toString()
+        );
     }
 
     /**
@@ -147,21 +155,16 @@ final public class TreeLogger {
     private <T> void stringPath0(final Collection<T> paths,
                                  final Function<T, StringPath> toStringPath,
                                  final TreeFormat format) {
-        this.indent();
-        {
-            switch (format) {
-                case FLAT:
-                    flat(paths, toStringPath, this.treePrinter);
-                    break;
-                case TREE:
-                    tree(paths, toStringPath, this.treePrinter);
-                    break;
-                default:
-                    NeverError.unhandledEnum(format, TreeFormat.values());
-            }
+        switch (format) {
+            case FLAT:
+                flat(paths, toStringPath, this.treePrinter);
+                break;
+            case TREE:
+                tree(paths, toStringPath, this.treePrinter);
+                break;
+            default:
+                NeverError.unhandledEnum(format, TreeFormat.values());
         }
-        this.outdent();
-        this.line(paths.size() + " file(s)");
     }
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/shade/J2clStepWorkerShadeJavaSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/shade/J2clStepWorkerShadeJavaSource.java
@@ -23,6 +23,7 @@ import walkingkooka.j2cl.maven.J2clMavenContext;
 import walkingkooka.j2cl.maven.J2clPath;
 import walkingkooka.j2cl.maven.J2clStep;
 import walkingkooka.j2cl.maven.J2clStepWorker;
+import walkingkooka.j2cl.maven.log.TreeFormat;
 import walkingkooka.j2cl.maven.log.TreeLogger;
 import walkingkooka.javashader.JavaShaders;
 
@@ -91,16 +92,19 @@ public final class J2clStepWorkerShadeJavaSource<C extends J2clMavenContext> ext
         logger.indent();
         {
             for (final J2clPath sourceRoot : sourceRoots) {
-                logger.line(sourceRoot.toString());
-                logger.indent();
-                {
-                    final Set<J2clPath> copy = sourceRoot.gatherFiles(J2clPath.JAVASCRIPT_FILES);
-                    output.copyFiles(sourceRoot,
-                            copy,
-                            J2clPath.COPY_FILE_CONTENT_VERBATIM,
-                            logger);
-                }
-                logger.outdent();
+                final Set<J2clPath> fromFiles = sourceRoot.gatherFiles(J2clPath.JAVASCRIPT_FILES);
+
+                output.copyFiles(
+                        sourceRoot,
+                        fromFiles,
+                        J2clPath.COPY_FILE_CONTENT_VERBATIM
+                );
+
+                logger.paths(
+                        "",
+                        fromFiles,
+                        TreeFormat.TREE
+                );
             }
         }
         logger.outdent();

--- a/src/main/java/walkingkooka/j2cl/maven/strip/GwtIncompatibleStripPreprocessor.java
+++ b/src/main/java/walkingkooka/j2cl/maven/strip/GwtIncompatibleStripPreprocessor.java
@@ -68,7 +68,11 @@ final class GwtIncompatibleStripPreprocessor {
             result = processStripAnnotationsFiles(javaFiles, output, logger);
 
             copyJavascriptFiles(sourceRoots, output, logger);
-            logger.paths("Output file(s)", output.gatherFiles(J2clPath.ALL_FILES), TreeFormat.TREE);
+            logger.paths(
+                    "Output file(s)",
+                    output.gatherFiles(J2clPath.ALL_FILES),
+                    TreeFormat.TREE
+            );
 
         } else {
             logger.indentedLine("No files found");
@@ -88,22 +92,36 @@ final class GwtIncompatibleStripPreprocessor {
         logger.line("Preparing java files");
         logger.indent();
         {
-            logger.indent();
-            {
-                for (final J2clPath sourceRoot : sourceRoots) {
-                    final Set<J2clPath> copied = gatherFiles(sourceRoot, J2clPath.JAVA_FILES);
+
+            for (final J2clPath sourceRoot : sourceRoots) {
+                {
+                    final Set<J2clPath> fromFiles = gatherFiles(
+                            sourceRoot,
+                            J2clPath.JAVA_FILES
+                    );
+
                     // find then copy from unpack to $output
-                    final Collection<J2clPath> files = output.copyFiles(sourceRoot,
-                            copied,
-                            J2clPath.COPY_FILE_CONTENT_VERBATIM,
-                            logger);
+                    final Collection<J2clPath> files = output.copyFiles(
+                            sourceRoot,
+                            fromFiles,
+                            J2clPath.COPY_FILE_CONTENT_VERBATIM
+                    );
+
+                    logger.paths(
+                            "",
+                            fromFiles,
+                            TreeFormat.TREE
+                    );
 
                     // necessary to prepare FileInfo with correct sourceRoot otherwise stripped files will be written back to the wrong place.
-                    javaFiles.addAll(J2clPath.toFileInfo(files, output));
+                    javaFiles.addAll(
+                            J2clPath.toFileInfo(
+                                    files,
+                                    output
+                            )
+                    );
                 }
             }
-            logger.outdent();
-            logger.line(javaFiles.size() + " file(s)");
         }
         logger.outdent();
 
@@ -151,17 +169,25 @@ final class GwtIncompatibleStripPreprocessor {
                                             final J2clPath output,
                                             final TreeLogger logger) throws IOException {
         logger.line("Copy *.js from source root(s) to output");
-        logger.indent();
-        {
-            for (final J2clPath sourceRoot : sourceRoots) {
-                final Set<J2clPath> copy = gatherFiles(sourceRoot, J2clPath.JAVASCRIPT_FILES);
-                output.copyFiles(sourceRoot,
-                        copy,
-                        J2clPath.COPY_FILE_CONTENT_VERBATIM,
-                        logger);
-            }
+
+        for (final J2clPath sourceRoot : sourceRoots) {
+            final Set<J2clPath> copy = gatherFiles(
+                    sourceRoot,
+                    J2clPath.JAVASCRIPT_FILES
+            );
+
+            output.copyFiles(
+                    sourceRoot,
+                    copy,
+                    J2clPath.COPY_FILE_CONTENT_VERBATIM
+            );
+
+            logger.paths(
+                    "",
+                    copy,
+                    TreeFormat.TREE
+            );
         }
-        logger.outdent();
     }
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/transpile/J2clStepWorkerJ2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/transpile/J2clStepWorkerJ2clTranspiler.java
@@ -64,11 +64,7 @@ public final class J2clStepWorkerJ2clTranspiler<C extends J2clMavenContext> impl
                                                final J2clStepDirectory directory,
                                                final C context,
                                                final TreeLogger logger) throws Exception {
-        logger.line("Preparing...");
-
         final J2clPath sourceRoot = this.sourceRoot(artifact);
-        logger.path("Source path(s)", sourceRoot);
-
         final Set<J2clPath> classpath = this.classpath(artifact);
 
         return J2clTranspiler.execute(classpath,

--- a/src/main/java/walkingkooka/j2cl/maven/transpile/J2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/transpile/J2clTranspiler.java
@@ -105,16 +105,18 @@ final class J2clTranspiler {
                     logger.line("Copy js to output");
                     logger.indent();
                     {
-                        output.copyFiles(sourcePath,
+                        output.copyFiles(
+                                sourcePath,
                                 jsInput,
-                                J2clPath.COPY_FILE_CONTENT_VERBATIM,
-                                logger);
+                                J2clPath.COPY_FILE_CONTENT_VERBATIM);
                     }
                     logger.outdent();
 
-                    logger.paths("File(s)",
+                    logger.paths(
+                            "Output",
                             output.gatherFiles(J2clPath.ALL_FILES),
-                            TreeFormat.TREE);
+                            TreeFormat.TREE
+                    );
                 }
             }
         }

--- a/src/test/java/walkingkooka/j2cl/maven/log/TreeLoggerTest.java
+++ b/src/test/java/walkingkooka/j2cl/maven/log/TreeLoggerTest.java
@@ -156,12 +156,13 @@ public final class TreeLoggerTest implements ClassTesting2<TreeLogger>, ToString
 
         logger.paths("label1", List.of(path("/path/2"), path("/path/1"), path("/path/3")), TreeFormat.FLAT);
 
-        this.check("label1\n" +
-                        "    /path/2<\n" +
-                        "    /path/1<\n" +
-                        "    /path/3<\n" +
-                        "  3 file(s)",
-                b);
+        this.check(
+                "label1\n" +
+                        "  /path/2<\n" +
+                        "  /path/1<\n" +
+                        "  /path/3<\n",
+                b
+        );
     }
 
     @Test
@@ -171,11 +172,12 @@ public final class TreeLoggerTest implements ClassTesting2<TreeLogger>, ToString
 
         logger.paths("label1", List.of(path("/path/to")), TreeFormat.TREE);
 
-        this.check("label1\n" +
-                        "    /path<\n" +
-                        "      to<\n" +
-                        "  1 file(s)",
-                b);
+        this.check(
+                "label1\n" +
+                        "  /path<\n" +
+                        "    to<\n",
+                b
+        );
     }
 
     @Test
@@ -185,11 +187,12 @@ public final class TreeLoggerTest implements ClassTesting2<TreeLogger>, ToString
 
         logger.paths("label1", List.of(path("/path/to"), path("/path/to2")), TreeFormat.TREE);
 
-        this.check("label1\n" +
-                        "    /path<\n" +
-                        "      to                                                           to2<\n" +
-                        "  2 file(s)",
-                b);
+        this.check(
+                "label1\n" +
+                        "  /path<\n" +
+                        "    to                                                           to2<\n",
+                b
+        );
     }
 
     @Test


### PR DESCRIPTION
- copy file operations now log source file tree not destination.
- removed "Extracting"
- removed some extra/unnecessary indentation in various Jobs.
- J2clPath.copyFiles removed logger parameter & now doesnt tree log or print file count.

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/509
- Unpack step missing source full path