### PR TITLE
J2clMavenContext with threadPoolSize rather than ExecutorService

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuild.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuild.java
@@ -79,7 +79,7 @@ public final class J2clMojoBuild extends J2clMojoBuildTest {
                 this.languageOut(),
                 this.sourceMaps(),
                 this.mavenMiddleware(),
-                this.executor(),
+                this.threadPoolSize(),
                 this.logger()
         );
     }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 /**
  * A {@link J2clMavenContext} that accompanies a build. The entry points and initial-script-filename are taken from the pom.
@@ -51,7 +50,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
                                           final LanguageMode languageOut,
                                           final Optional<String> sourceMaps,
                                           final J2clMavenMiddleware middleware,
-                                          final ExecutorService executor,
+                                          final int threadPoolSize,
                                           final MavenLogger logger) {
         return new J2clMojoBuildMavenContext(
                 cache,
@@ -70,7 +69,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
                 languageOut,
                 sourceMaps,
                 middleware,
-                executor,
+                threadPoolSize,
                 logger
         );
     }
@@ -91,7 +90,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
                                       final LanguageMode languageOut,
                                       final Optional<String> sourceMaps,
                                       final J2clMavenMiddleware middleware,
-                                      final ExecutorService executor,
+                                      final int threadPoolSize,
                                       final MavenLogger logger) {
         super(
                 cache,
@@ -108,7 +107,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
                 languageOut,
                 sourceMaps,
                 middleware,
-                executor,
+                threadPoolSize,
                 logger
         );
         this.entryPoints = entryPoints;

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildTest.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildTest.java
@@ -43,8 +43,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 /**
@@ -264,17 +262,6 @@ abstract class J2clMojoBuildTest extends J2clMojo {
 
     // threadPool.......................................................................................................
 
-    final ExecutorService executor() {
-        final int threadPoolSize = this.threadPoolSize;
-        if (threadPoolSize < 0) {
-            throw new IllegalStateException("Invalid threadPoolSize expected 0 to select CPU cores *2, or a positive value but got " + threadPoolSize);
-        }
-
-        return Executors.newFixedThreadPool(0 != threadPoolSize ?
-                threadPoolSize :
-                Runtime.getRuntime().availableProcessors() * 2);
-    }
-
     /**
      * If a value of zero is passed or defaulted the a thread pool equal to the CPU core count * 2 is created.
      * <br>
@@ -285,6 +272,15 @@ abstract class J2clMojoBuildTest extends J2clMojo {
             readonly = true,
             required = true)
     private int threadPoolSize;
+
+    final int threadPoolSize() {
+        final int threadPoolSize = this.threadPoolSize;
+        if (threadPoolSize < 0) {
+            throw new IllegalStateException("Invalid threadPoolSize expected 0 to select CPU cores *2, or a positive value but got " + threadPoolSize);
+        }
+
+        return threadPoolSize;
+    }
 
     // mavenMiddleware..................................................................................................
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
@@ -127,7 +127,7 @@ public final class J2clMojoTest extends J2clMojoBuildTest {
                 testClassName,
                 this.testTimeout(),
                 this.mavenMiddleware(),
-                this.executor(),
+                this.threadPoolSize(),
                 this.logger());
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 /**
  * A {@link J2clMavenContext} that accompanies a test. The entry points and initial-script-filename are NOT taken from the pom,
@@ -56,7 +55,7 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
                                          final String testClassName,
                                          final int testTimeout,
                                          final J2clMavenMiddleware middleware,
-                                         final ExecutorService executor,
+                                         final int threadPoolSize,
                                          final MavenLogger logger) {
         return new J2clMojoTestMavenContext(
                 cache,
@@ -77,7 +76,7 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
                 testClassName,
                 testTimeout,
                 middleware,
-                executor,
+                threadPoolSize,
                 logger
         );
     }
@@ -100,7 +99,7 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
                                      final String testClassName,
                                      final int testTimeout,
                                      final J2clMavenMiddleware middleware,
-                                     final ExecutorService executor,
+                                     final int threadPoolSize,
                                      final MavenLogger logger) {
         super(
                 cache,
@@ -117,7 +116,7 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
                 languageOut,
                 sourceMaps,
                 middleware,
-                executor,
+                threadPoolSize,
                 logger
         );
         this.browsers = browsers;


### PR DESCRIPTION
- The ExecutorService and CompletionService will be created when the build is executed rather than in the ctor, allow a future watch task to recreate instances in each build.