### PR TITLE
J2clStep honours result when fetching next

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clStep.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStep.java
@@ -225,11 +225,13 @@ public enum J2clStep {
         );
 
         try {
+            J2clStepResult result = J2clStepResult.ABORTED;
+
             if (!artifact.isDependency() || !this.skipIfDependency()) {
                 logger.line(prefix);
                 logger.indent();
 
-                final J2clStepResult result = this.execute0()
+                result = this.execute0()
                         .execute(
                                 artifact,
                                 this,
@@ -249,7 +251,7 @@ public enum J2clStep {
 
                 result.reportIfFailure(artifact, this);
             }
-            return context.nextStep(this);
+            return result.next(this, context);
         } catch (final Exception cause) {
             logger.error("Failed to execute " + prefix + " message: " + cause.getMessage(), cause);
             logger.flush();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStepResult.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStepResult.java
@@ -29,8 +29,13 @@ public enum J2clStepResult {
             return directory.aborted();
         }
 
+        /**
+         * NOT a fail but skip remaining steps for this dependency. Used by HASH when the computed hash is the same as previous,
+         * and theres no point redoing tasks.
+         */
         @Override
-        Optional<J2clStep> next(final Optional<J2clStep> next) {
+        Optional<J2clStep> next(final J2clStep current,
+                                final J2clMavenContext context) {
             return Optional.empty();
         }
     },
@@ -43,8 +48,12 @@ public enum J2clStepResult {
             return directory.failed();
         }
 
+        /**
+         * An error occurred, eg a java compile error no point trying further steps for this dependency.
+         */
         @Override
-        Optional<J2clStep> next(final Optional<J2clStep> next) {
+        Optional<J2clStep> next(final J2clStep current,
+                                final J2clMavenContext context) {
             return Optional.empty();
         }
     },
@@ -58,8 +67,9 @@ public enum J2clStepResult {
         }
 
         @Override
-        Optional<J2clStep> next(final Optional<J2clStep> next) {
-            return next;
+        Optional<J2clStep> next(final J2clStep current,
+                                final J2clMavenContext context) {
+            return context.nextStep(current);
         }
     },
     /**
@@ -72,8 +82,9 @@ public enum J2clStepResult {
         }
 
         @Override
-        Optional<J2clStep> next(final Optional<J2clStep> next) {
-            return next;
+        Optional<J2clStep> next(final J2clStep current,
+                                final J2clMavenContext context) {
+            return context.nextStep(current);
         }
     };
 
@@ -89,5 +100,6 @@ public enum J2clStepResult {
         }
     }
 
-    abstract Optional<J2clStep> next(final Optional<J2clStep> next);
+    abstract Optional<J2clStep> next(final J2clStep current,
+                                     final J2clMavenContext context);
 }


### PR DESCRIPTION
- First step in updating Hash to return ABORT and skip remaining steps when hash hasnt changed.