### PR TITLE
TreeLogger internal isDebugEnabled guards

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/log/MavenLogger.java
+++ b/src/main/java/walkingkooka/j2cl/maven/log/MavenLogger.java
@@ -63,7 +63,8 @@ public interface MavenLogger {
         return TreeLogger.with(
                 this::debug,
                 this::info,
-                this::error
+                this::error,
+                this.isDebugEnabled()
         );
     }
 }

--- a/src/test/java/walkingkooka/j2cl/maven/log/TreeLoggerTest.java
+++ b/src/test/java/walkingkooka/j2cl/maven/log/TreeLoggerTest.java
@@ -291,7 +291,8 @@ public final class TreeLoggerTest implements ClassTesting2<TreeLogger> {
                         .append(EOL),
                 (line, cause) -> {
                     throw new UnsupportedOperationException();
-                }
+                },
+                true // isDebugEnabled
         );
     }
 
@@ -301,7 +302,8 @@ public final class TreeLoggerTest implements ClassTesting2<TreeLogger> {
                 (line) -> b.append(line).append(EOL),
                 (line, cause) -> {
                     throw new UnsupportedOperationException();
-                }
+                },
+                true // isDebugEnabled
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/j2cl-maven-plugin/issues/528
- TreeLogger should test if debug is enabled when printing tables