### PR TITLE
watch task: file-watch-skip-dependencies

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clDependency.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clDependency.java
@@ -633,6 +633,19 @@ public final class J2clDependency implements Comparable<J2clDependency> {
         });
     }
 
+    /**
+     * Tests if the dependency should not have a job submitted.
+     */
+    boolean shouldSkipJobSubmit() {
+        return this.isAnnotationProcessor() ||
+                this.isAnnotationClassFiles() ||
+                this.isJreBootstrapClassFiles() ||
+                this.isJreClassFiles() ||
+                this.isJreJavascriptBootstrapFiles() ||
+                this.isJreJavascriptFiles() ||
+                this.isIgnored();
+    }
+
     // print............................................................................................................
 
     /**

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
@@ -268,49 +268,23 @@ public abstract class J2clMavenContext implements Context {
 
             this.jobs.put(artifact, required);
 
-            for (final J2clDependency dependency : artifact.dependencies()) {
-                if (shouldSkipDependency(dependency)) {
-                    continue;
-                }
+            if (!this.shouldSkipSubmittingDependencyJobs()) {
+                for (final J2clDependency dependency : artifact.dependencies()) {
+                    if (dependency.shouldSkipJobSubmit()) {
+                        continue;
+                    }
 
-                required.add(dependency);
-                this.prepareJobs(dependency);
+                    required.add(dependency);
+                    this.prepareJobs(dependency);
+                }
             }
         }
     }
 
     /**
-     * Tests if the dependency should not have a job submitted.
+     * Only watch during the file event watch phase will return true.
      */
-    private boolean shouldSkipDependency(final J2clDependency dependency) {
-        final boolean skip;
-
-        do {
-            if (dependency.isAnnotationProcessor() || dependency.isAnnotationClassFiles()) {
-                skip = true;
-                break;
-            }
-
-            if (dependency.isJreBootstrapClassFiles() || dependency.isJreClassFiles()) {
-                skip = true;
-                break;
-            }
-
-            if (dependency.isJreJavascriptBootstrapFiles() || dependency.isJreJavascriptFiles()) {
-                skip = true;
-                break;
-            }
-
-            if (dependency.isIgnored()) {
-                skip = true;
-                break;
-            }
-
-            skip = false;
-        } while (false);
-
-        return skip;
-    }
+    abstract boolean shouldSkipSubmittingDependencyJobs();
 
     /**
      * Loops over all {@link #jobs} submitting a job for each that has no required artifacts aka the value is an empty {@link Set}.

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -168,4 +168,11 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
             J2clStep.CLOSURE_COMPILE,
             J2clStep.OUTPUT_ASSEMBLE
     );
+
+    // J2clMavenContext.................................................................................................
+
+    @Override
+    boolean shouldSkipSubmittingDependencyJobs() {
+        return false;
+    }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -183,6 +183,13 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
             J2clStep.JUNIT_TESTS
     );
 
+    // J2clMavenContext.................................................................................................
+
+    @Override
+    boolean shouldSkipSubmittingDependencyJobs() {
+        return false;
+    }
+
     // test only props..................................................................................................
 
     public List<J2clStepWorkerWebDriverUnitTestRunnerBrowser> browsers() {

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
@@ -58,6 +58,14 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     }
 
     /**
+     * During the file watch phase, where the {@link #buildOutputDirectory} is watched and the project rebuilt,
+     * dependencies are assumed not to have changed and only the project and its files will be processed.
+     */
+    @Parameter(alias = "file-watch-skip-dependencies",
+            required = true)
+    private boolean fileWatchSkipDependencies;
+
+    /**
      * Watches the output directory where the IDE places class files.
      */
     @Override
@@ -122,6 +130,13 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     private void waitAndBuild(final Path buildOutputDirectory, final J2clDependency project,
                               final TreeLogger logger,
                               final J2clMojoWatchMavenContext context) {
+        final boolean fileWatchSkipDependencies = this.fileWatchSkipDependencies;
+        context.shouldSkipSubmittingJobs = fileWatchSkipDependencies;
+
+        if (fileWatchSkipDependencies) {
+            logger.line("All Dependencies will NOT be processed again following a file event.");
+        }
+
         for (; ; ) {
             try (final WatchService watchService = watchService(buildOutputDirectory)) {
                 new WatchablePath(buildOutputDirectory).register(

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -174,4 +174,14 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
             J2clStep.CLOSURE_COMPILE,
             J2clStep.OUTPUT_ASSEMBLE
     );
+
+    // J2clMavenContext.................................................................................................
+
+    @Override
+    boolean shouldSkipSubmittingDependencyJobs() {
+        return this.shouldSkipSubmittingJobs;
+    }
+
+    // initially false but will take the watch-task.fileWatchSkipDependencies
+    boolean shouldSkipSubmittingJobs = false;
 }


### PR DESCRIPTION
- During the file event watch phase dependencies are not processed again. If they have changed the user will need to kill the task and re-run.

- J2clDependency.shouldSkipJobSubmit moved from J2clMavenContext.