### PR TITLE
watch task property: file-watch-skip-dependencies removed

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
@@ -58,14 +58,6 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     }
 
     /**
-     * During the file watch phase, where the {@link #buildOutputDirectory} is watched and the project rebuilt,
-     * dependencies are assumed not to have changed and only the project and its files will be processed.
-     */
-    @Parameter(alias = "file-watch-skip-dependencies",
-            required = true)
-    private boolean fileWatchSkipDependencies;
-
-    /**
      * Watches the output directory where the IDE places class files.
      */
     @Override
@@ -130,14 +122,7 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     private void waitAndBuild(final Path buildOutputDirectory, final J2clDependency project,
                               final TreeLogger logger,
                               final J2clMojoWatchMavenContext context) {
-        final boolean fileWatchSkipDependencies = this.fileWatchSkipDependencies;
-        context.shouldSkipSubmittingJobs = fileWatchSkipDependencies;
-
-        if (fileWatchSkipDependencies) {
-            logger.line("All Dependencies will NOT be processed again following a file event.");
-            logger.lineStart();
-            logger.flush();
-        }
+        context.fileEventPhase = true;
 
         for (; ; ) {
             try (final WatchService watchService = watchService(buildOutputDirectory)) {

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -179,9 +179,8 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
 
     @Override
     boolean shouldSkipSubmittingDependencyJobs() {
-        return this.shouldSkipSubmittingJobs;
+        return this.fileEventPhase;
     }
 
-    // initially false but will take the watch-task.fileWatchSkipDependencies
-    boolean shouldSkipSubmittingJobs = false;
+    boolean fileEventPhase = false;
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/j2cl-maven-plugin/issues/551
- README: watch-task: file-watch-skip-dependencies