### PR TITLE
watch task: new file events kill executing tasks

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuild.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuild.java
@@ -44,10 +44,11 @@ public final class J2clMojoBuild extends J2clMojoBuildWatch {
                     logger,
                     context
             );
-            context.execute(
+            context.prepareAndStart(
                     project,
                     logger
             );
+            context.waitUntilCompletion();
         } catch (final Throwable e) {
             throw new MojoExecutionException("Failed to build project, check logs above", e);
         }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -24,6 +24,7 @@ import walkingkooka.j2cl.maven.closure.ClosureFormattingOption;
 import walkingkooka.j2cl.maven.hash.HashBuilder;
 import walkingkooka.j2cl.maven.log.MavenLogger;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -168,6 +169,11 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
             J2clStep.CLOSURE_COMPILE,
             J2clStep.OUTPUT_ASSEMBLE
     );
+
+    @Override
+    public boolean shouldCheckCache() {
+        return true;
+    }
 
     // J2clMavenContext.................................................................................................
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTest.java
@@ -91,10 +91,11 @@ public final class J2clMojoTest extends J2clMojoBuildTestWatch {
 
                     try {
                         context.setProject(project);
-                        context.execute(
+                        context.prepareAndStart(
                                 project,
                                 logger
                         );
+                        context.waitUntilCompletion();
                     } catch (final Throwable cause) {
                         throw new MojoExecutionException("Failed to build project, check logs above", cause);
                     }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -26,6 +26,7 @@ import walkingkooka.j2cl.maven.log.BrowserLogLevel;
 import walkingkooka.j2cl.maven.log.MavenLogger;
 import walkingkooka.j2cl.maven.test.J2clStepWorkerWebDriverUnitTestRunnerBrowser;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -182,6 +183,11 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
             J2clStep.CLOSURE_COMPILE,
             J2clStep.JUNIT_TESTS
     );
+
+    @Override
+    public boolean shouldCheckCache() {
+        return true;
+    }
 
     // J2clMavenContext.................................................................................................
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -24,6 +24,7 @@ import walkingkooka.j2cl.maven.closure.ClosureFormattingOption;
 import walkingkooka.j2cl.maven.hash.HashBuilder;
 import walkingkooka.j2cl.maven.log.MavenLogger;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -174,6 +175,11 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
             J2clStep.CLOSURE_COMPILE,
             J2clStep.OUTPUT_ASSEMBLE
     );
+
+    @Override
+    public boolean shouldCheckCache() {
+        return false == this.fileEventPhase;
+    }
 
     // J2clMavenContext.................................................................................................
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clStep.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clStep.java
@@ -247,7 +247,8 @@ public enum J2clStep {
                         logger
                 );
 
-                result.path(directory).createIfNecessary();
+                result.path(directory)
+                        .createIfNecessary();
 
                 result.reportIfFailure(artifact, this);
             }
@@ -283,7 +284,6 @@ public enum J2clStep {
 
                 Files.write(base, lines);
             }
-            context.cancel(cause);
 
             throw cause;
         }

--- a/src/main/java/walkingkooka/j2cl/maven/hash/J2clStepWorkerHash.java
+++ b/src/main/java/walkingkooka/j2cl/maven/hash/J2clStepWorkerHash.java
@@ -80,7 +80,7 @@ public final class J2clStepWorkerHash<C extends J2clMavenContext> implements J2c
         final J2clPath directory = artifact.setDirectory(
                 hash.build()
         ).directory();
-        if (directory.exists().isPresent()) {
+        if (context.shouldCheckCache() && directory.exists().isPresent()) {
             result = J2clStepResult.ABORTED; // computed hash must not have changed dir already exists so skip remaining tasks.
         } else {
             // create the dir that will have hash step so the file can be written...


### PR DESCRIPTION
- new file events will be abandoned when step finishes and then restarts (immediate kills will leave maven downloads with. bad files seem to cause future retries of task to fail).
- result directories are ignored, this is necessary as multiple file events could cause one build to be aborted and then restarted.
- watch file change rebuild of vertispan:connected now 8.5secs with log=INFO and 11 with DEBUG (about half). Still plenty of opportunities to reduce time.

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/541
- watch task: new file events should terminate any executing build

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/540
- Watch runs unnecessarily twice