### PR TITLE
J2clMavenContext task J2clArtifact parameter

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clArtifact.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clArtifact.java
@@ -1236,7 +1236,10 @@ public final class J2clArtifact implements Comparable<J2clArtifact> {
         return J2clTaskDirectory.with(
                 Paths.get(
                         this.directory().toString(),
-                        this.context.directoryName(kind)
+                        this.context.directoryName(
+                                this,
+                                kind
+                        )
                 )
         );
     }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
@@ -180,7 +180,7 @@ public abstract class J2clMavenContext implements Context {
 
     private final Set<ClosureFormattingOption> formatting;
 
-    public abstract J2clPath initialScriptFilename();
+    public abstract J2clPath initialScriptFilename(final J2clArtifact artifact);
 
     private final Set<String> javaCompilerArguments;
 
@@ -214,19 +214,22 @@ public abstract class J2clMavenContext implements Context {
                 .output();
     }
 
-    public final String directoryName(final J2clTaskKind kind) {
+    public final String directoryName(final J2clArtifact artifact,
+                                      final J2clTaskKind kind) {
         return kind.directoryName(
-                this.tasks()
+                this.tasks(artifact)
                         .indexOf(kind)
         );
     }
 
-    final J2clTaskKind firstTaskKind() {
-        return this.tasks().get(0);
+    final J2clTaskKind firstTaskKind(final J2clArtifact artifact) {
+        return this.tasks(artifact)
+                .get(0);
     }
 
-    final Optional<J2clTaskKind> nextTask(final J2clTaskKind current) {
-        final List<J2clTaskKind> tasks = this.tasks();
+    final Optional<J2clTaskKind> nextTask(final J2clArtifact artifact,
+                                          final J2clTaskKind current) {
+        final List<J2clTaskKind> tasks = this.tasks(artifact);
 
         final int index = tasks.indexOf(current);
         return Optional.ofNullable(
@@ -236,7 +239,7 @@ public abstract class J2clMavenContext implements Context {
         );
     }
 
-    abstract List<J2clTaskKind> tasks();
+    abstract List<J2clTaskKind> tasks(final J2clArtifact artifact);
 
     /**
      * When true directories like !SUCCESS should be checked and honoured.
@@ -408,7 +411,8 @@ public abstract class J2clMavenContext implements Context {
             logger.line(coords);
             logger.indent();
             {
-                J2clTaskKind kind = this.firstTaskKind();
+                J2clTaskKind kind = this.firstTaskKind(artifact);
+
                 do {
                     // skip this and any more tasks, watch task probably issued a shutdown because of a new file watch event.
                     if (!this.isRunning()) {
@@ -723,7 +727,6 @@ public abstract class J2clMavenContext implements Context {
                 this.entryPoints() + " " +
                 this.externs + " " +
                 this.formatting + " " +
-                this.initialScriptFilename() + " " +
                 this.languageOut + " " +
                 this.sourceMaps + " " +
                 this.level;

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -127,7 +127,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
     private final List<String> entryPoints;
 
     @Override
-    public J2clPath initialScriptFilename() {
+    public J2clPath initialScriptFilename(final J2clArtifact artifact) {
         return this.initialScriptFilename;
     }
 
@@ -152,7 +152,7 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
     // tasks....................................................................................................
 
     @Override
-    List<J2clTaskKind> tasks() {
+    List<J2clTaskKind> tasks(final J2clArtifact artifact) {
         return TASKS;
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -137,10 +137,14 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
     }
 
     @Override
-    public J2clPath initialScriptFilename() {
+    public J2clPath initialScriptFilename(final J2clArtifact artifact) {
         return this.project.directory()
-                .append(this.directoryName(J2clTaskKind.CLOSURE_COMPILE))
-                .output()
+                .append(
+                        this.directoryName(
+                                artifact,
+                                J2clTaskKind.CLOSURE_COMPILE
+                        )
+                ).output()
                 .append(this.testClassName + ".js");
     }
 
@@ -166,7 +170,7 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
     // tasks............................................................................................................
 
     @Override
-    List<J2clTaskKind> tasks() {
+    List<J2clTaskKind> tasks(final J2clArtifact artifact) {
         return TASKS;
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -127,7 +127,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
     private final List<String> entryPoints;
 
     @Override
-    public J2clPath initialScriptFilename() {
+    public J2clPath initialScriptFilename(final J2clArtifact artifact) {
         return this.initialScriptFilename;
     }
 
@@ -154,7 +154,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
     // tasks............................................................................................................
 
     @Override
-    List<J2clTaskKind> tasks() {
+    List<J2clTaskKind> tasks(final J2clArtifact artifact) {
         return TASKS;
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -336,13 +336,16 @@ public final class J2clPath implements Comparable<J2clPath> {
     /**
      * Only returns true if this path is the output directory of an UNPACK.
      */
-    public boolean isUnpackOutput(final J2clMavenContext context) {
+    public boolean isUnpackOutput(final J2clArtifact artifact,
+                                  final J2clMavenContext context) {
         return this.filename().equals(OUTPUT) &&
                 this.path()
                         .getParent()
                         .getFileName()
                         .toString()
-                        .equals(context.directoryName(J2clTaskKind.UNPACK));
+                        .equals(
+                                context.directoryName(artifact, J2clTaskKind.UNPACK)
+                        );
     }
 
     private final static String OUTPUT = "output";

--- a/src/main/java/walkingkooka/j2cl/maven/J2clTaskKind.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clTaskKind.java
@@ -263,7 +263,11 @@ public enum J2clTaskKind {
 
                 result.reportIfFailure(artifact, this);
             }
-            return result.next(this, context);
+            return result.next(
+                    artifact,
+                    this,
+                    context
+            );
         } catch (final Exception cause) {
             logger.error("Failed to execute " + prefix + " message: " + cause.getMessage(), cause);
             logger.flush();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clTaskResult.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clTaskResult.java
@@ -34,7 +34,8 @@ public enum J2clTaskResult {
          * and theres no point redoing tasks.
          */
         @Override
-        Optional<J2clTaskKind> next(final J2clTaskKind current,
+        Optional<J2clTaskKind> next(final J2clArtifact artifact,
+                                    final J2clTaskKind current,
                                     final J2clMavenContext context) {
             return Optional.empty();
         }
@@ -52,7 +53,8 @@ public enum J2clTaskResult {
          * An error occurred, eg a java compile error no point trying further tasks for this dependency.
          */
         @Override
-        Optional<J2clTaskKind> next(final J2clTaskKind current,
+        Optional<J2clTaskKind> next(final J2clArtifact artifact,
+                                    final J2clTaskKind current,
                                     final J2clMavenContext context) {
             return Optional.empty();
         }
@@ -67,9 +69,13 @@ public enum J2clTaskResult {
         }
 
         @Override
-        Optional<J2clTaskKind> next(final J2clTaskKind current,
+        Optional<J2clTaskKind> next(final J2clArtifact artifact,
+                                    final J2clTaskKind current,
                                     final J2clMavenContext context) {
-            return context.nextTask(current);
+            return context.nextTask(
+                    artifact,
+                    current
+            );
         }
     },
     /**
@@ -82,9 +88,13 @@ public enum J2clTaskResult {
         }
 
         @Override
-        Optional<J2clTaskKind> next(final J2clTaskKind current,
+        Optional<J2clTaskKind> next(final J2clArtifact artifact,
+                                    final J2clTaskKind current,
                                     final J2clMavenContext context) {
-            return context.nextTask(current);
+            return context.nextTask(
+                    artifact,
+                    current
+            );
         }
     };
 
@@ -100,6 +110,7 @@ public enum J2clTaskResult {
         }
     }
 
-    abstract Optional<J2clTaskKind> next(final J2clTaskKind current,
+    abstract Optional<J2clTaskKind> next(final J2clArtifact artifact,
+                                         final J2clTaskKind current,
                                          final J2clMavenContext context);
 }

--- a/src/main/java/walkingkooka/j2cl/maven/closure/ClosureCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/closure/ClosureCompiler.java
@@ -26,6 +26,7 @@ import com.google.javascript.jscomp.DependencyOptions;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.j2cl.maven.J2clArtifact;
 import walkingkooka.j2cl.maven.J2clMavenContext;
 import walkingkooka.j2cl.maven.J2clPath;
 import walkingkooka.j2cl.maven.log.TreeFormat;
@@ -50,7 +51,8 @@ import java.util.stream.Collectors;
 
 class ClosureCompiler {
 
-    static boolean compile(final CompilationLevel compilationLevel,
+    static boolean compile(final J2clArtifact artifact,
+                           final CompilationLevel compilationLevel,
                            final Map<String, String> defines,
                            final List<String> entryPoints,
                            final Set<String> externs,
@@ -64,6 +66,7 @@ class ClosureCompiler {
                            final J2clMavenContext context,
                            final TreeLogger logger) throws Exception {
         return compile0(
+                artifact,
                 compilationLevel,
                 defines,
                 entryPoints,
@@ -80,7 +83,8 @@ class ClosureCompiler {
         );
     }
 
-    private static boolean compile0(final CompilationLevel compilationLevel,
+    private static boolean compile0(final J2clArtifact artifact,
+                                    final CompilationLevel compilationLevel,
                                     final Map<String, String> defines,
                                     final List<String> entryPoints,
                                     final SortedSet<String> externs,
@@ -118,7 +122,10 @@ class ClosureCompiler {
                     logger.outdent();
                 } else {
                     // if unpack/output dont want to copy java source.
-                    final Predicate<Path> filter = sourceRoot.isUnpackOutput(context) ?
+                    final Predicate<Path> filter = sourceRoot.isUnpackOutput(
+                            artifact,
+                            context
+                    ) ?
                             J2clPath.ALL_FILES_EXCEPT_JAVA :
                             J2clPath.ALL_FILES;
 

--- a/src/main/java/walkingkooka/j2cl/maven/closure/J2clTaskClosureCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/closure/J2clTaskClosureCompiler.java
@@ -116,6 +116,7 @@ public final class J2clTaskClosureCompiler<C extends J2clMavenContext> implement
         }
 
         return ClosureCompiler.compile(
+                artifact,
                 context.level(),
                 context.defines(),
                 context.entryPoints(),
@@ -126,7 +127,8 @@ public final class J2clTaskClosureCompiler<C extends J2clMavenContext> implement
                 context.sourceMaps(),
                 sources,
                 directory.output().createIfNecessary(),
-                context.initialScriptFilename().filename(),
+                context.initialScriptFilename(artifact)
+                        .filename(),
                 context,
                 logger
         ) ?

--- a/src/main/java/walkingkooka/j2cl/maven/hash/J2clTaskHash.java
+++ b/src/main/java/walkingkooka/j2cl/maven/hash/J2clTaskHash.java
@@ -84,8 +84,12 @@ public final class J2clTaskHash<C extends J2clMavenContext> implements J2clTask<
             result = J2clTaskResult.ABORTED; // computed hash must not have changed dir already exists so skip remaining tasks.
         } else {
             // create the dir that will have hash task so the file can be written...
-            directory.append(context.directoryName(J2clTaskKind.HASH))
-                    .createIfNecessary();
+            directory.append(
+                    context.directoryName(
+                            artifact,
+                            J2clTaskKind.HASH
+                    )
+            ).createIfNecessary();
 
             final J2clTaskDirectory hashDirectory = artifact.taskDirectory(J2clTaskKind.HASH);
             final String txt = hashItemNames.stream()

--- a/src/main/java/walkingkooka/j2cl/maven/test/J2clTaskWebDriverUnitTestRunner.java
+++ b/src/main/java/walkingkooka/j2cl/maven/test/J2clTaskWebDriverUnitTestRunner.java
@@ -83,7 +83,11 @@ public final class J2clTaskWebDriverUnitTestRunner implements J2clTask<J2clMojoT
         logger.indent();
         {
             this.executeTestSuite(
-                    this.prepareJunitHostFileScriptPath(context, logger),
+                    this.prepareJunitHostFileScriptPath(
+                            artifact,
+                            context,
+                            logger
+                    ),
                     context.browsers(),
                     context.browserLogLevel(),
                     context.testTimeout(),
@@ -98,14 +102,15 @@ public final class J2clTaskWebDriverUnitTestRunner implements J2clTask<J2clMojoT
     /**
      * Loads the html file and replaces the script file with the closure compiled test file.
      */
-    private J2clPath prepareJunitHostFileScriptPath(final J2clMavenContext context,
+    private J2clPath prepareJunitHostFileScriptPath(final J2clArtifact artifact,
+                                                    final J2clMavenContext context,
                                                     final TreeLogger logger) throws IOException {
         final J2clPath hostHtml;
 
         logger.line("Prepare host file");
         logger.indent();
         {
-            final J2clPath file = context.initialScriptFilename();
+            final J2clPath file = context.initialScriptFilename(artifact);
             hostHtml = file.parent()
                     .append(CharSequences.subSequence(file.file().getName(), 0, -2) + "html");
 


### PR DESCRIPTION
- In preparation for watch rebuild first task starting at incompatible-strip, not hash.
- Also necessary for tasks only including unpack for dependencies and not main project.