### PR TITLE
J2clTaskJavacCompiler.sourceRoots refactoring

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerGwtIncompatibleStrippedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerGwtIncompatibleStrippedSource.java
@@ -48,8 +48,14 @@ public final class J2clTaskJavacCompilerGwtIncompatibleStrippedSource<C extends 
     }
 
     @Override
-    J2clTaskKind sourceTask() {
-        return J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE;
+    List<J2clPath> sourceRoots(final J2clArtifact artifact,
+                               final C context,
+                               final TreeLogger logger) {
+        return Lists.of(
+                artifact.taskDirectory(
+                        J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE
+                ).output()
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
@@ -51,8 +51,14 @@ public final class J2clTaskJavacCompilerUnpackedSource<C extends J2clMavenContex
     }
 
     @Override
-    J2clTaskKind sourceTask() {
-        return J2clTaskKind.UNPACK;
+    List<J2clPath> sourceRoots(final J2clArtifact artifact,
+                               final C context,
+                               final TreeLogger logger) {
+        return Lists.of(
+                artifact.taskDirectory(
+                        J2clTaskKind.UNPACK
+                ).output()
+        );
     }
 
     @Override


### PR DESCRIPTION
- Previously each of the two sub classes return a J2clTaskKind, now a new method (sourceRoots) has been introduced.