### PR TITLE
Unpack skipped for project but not dependencies artifacts

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
@@ -203,6 +203,12 @@ public abstract class J2clMavenContext implements Context {
     // tasks............................................................................................................
 
     public final List<J2clPath> sources(final J2clArtifact artifact) {
+        return artifact.isDependency() ?
+                this.unpackOutputDirectory(artifact) :
+                artifact.sourcesRoot();
+    }
+
+    private List<J2clPath> unpackOutputDirectory(final J2clArtifact artifact) {
         return Lists.of(
                 artifact.taskDirectory(J2clTaskKind.UNPACK)
                         .output()

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -153,12 +153,26 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
 
     @Override
     List<J2clTaskKind> tasks(final J2clArtifact artifact) {
-        return TASKS;
+        return artifact.isDependency() ?
+                DEPENDENCY_TASKS :
+                PROJECT_TASKS;
     }
 
-    private final List<J2clTaskKind> TASKS = Lists.of(
+    private final List<J2clTaskKind> DEPENDENCY_TASKS = Lists.of(
             J2clTaskKind.HASH,
             J2clTaskKind.UNPACK,
+            J2clTaskKind.JAVAC_COMPILE,
+            J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
+            J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
+            J2clTaskKind.SHADE_JAVA_SOURCE,
+            J2clTaskKind.SHADE_CLASS_FILES,
+            J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT,
+            J2clTaskKind.CLOSURE_COMPILE,
+            J2clTaskKind.OUTPUT_ASSEMBLE
+    );
+
+    private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
+            J2clTaskKind.HASH,
             J2clTaskKind.JAVAC_COMPILE,
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -171,12 +171,26 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
 
     @Override
     List<J2clTaskKind> tasks(final J2clArtifact artifact) {
-        return TASKS;
+        return artifact.isDependency() ?
+                DEPENDENCY_TASKS :
+                PROJECT_TASKS;
     }
 
-    private final List<J2clTaskKind> TASKS = Lists.of(
+    private final List<J2clTaskKind> DEPENDENCY_TASKS = Lists.of(
             J2clTaskKind.HASH,
             J2clTaskKind.UNPACK,
+            J2clTaskKind.JAVAC_COMPILE,
+            J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
+            J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
+            J2clTaskKind.SHADE_JAVA_SOURCE,
+            J2clTaskKind.SHADE_CLASS_FILES,
+            J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT,
+            J2clTaskKind.CLOSURE_COMPILE,
+            J2clTaskKind.JUNIT_TESTS
+    );
+
+    private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
+            J2clTaskKind.HASH,
             J2clTaskKind.JAVAC_COMPILE,
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -155,16 +155,30 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
 
     @Override
     List<J2clTaskKind> tasks(final J2clArtifact artifact) {
-        return TASKS;
+        return artifact.isDependency() ?
+                DEPENDENCY_TASKS :
+                PROJECT_TASKS;
     }
 
     /**
      * When real file watch and compute affected classes are functional this list of tasks will change and begin with
      * {@link J2clTaskKind#GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE}.
      */
-    private final List<J2clTaskKind> TASKS = Lists.of(
+    private final List<J2clTaskKind> DEPENDENCY_TASKS = Lists.of(
             J2clTaskKind.HASH,
             J2clTaskKind.UNPACK,
+            J2clTaskKind.JAVAC_COMPILE,
+            J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
+            J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
+            J2clTaskKind.SHADE_JAVA_SOURCE,
+            J2clTaskKind.SHADE_CLASS_FILES,
+            J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT,
+            J2clTaskKind.CLOSURE_COMPILE,
+            J2clTaskKind.OUTPUT_ASSEMBLE
+    );
+
+    private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
+            J2clTaskKind.HASH,
             J2clTaskKind.JAVAC_COMPILE,
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -346,7 +346,8 @@ public final class J2clPath implements Comparable<J2clPath> {
      */
     public boolean isUnpackOutput(final J2clArtifact artifact,
                                   final J2clMavenContext context) {
-        return this.filename().equals(OUTPUT) &&
+        return artifact.isDependency() &&
+                this.filename().equals(OUTPUT) &&
                 this.path()
                         .getParent()
                         .getFileName()

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompiler.java
@@ -68,9 +68,17 @@ abstract class J2clTaskJavacCompiler<C extends J2clMavenContext> implements J2cl
         final Set<J2clPath> classpath = Sets.ordered();
 
         for (final J2clPath source : this.sourceRoots(artifact, context, logger)) {
+            // /Users/miroslav/repos-github/j2cl-maven-plugin/target/it-tests/junit-test-dependency-graph/test/src/test/java
+            // /Users/miroslav/repos-github/j2cl-maven-plugin/target/it-tests/junit-test-dependency-graph/test/target/generated-test-sources/test-annotations
+            if (source.isGeneratedDirectory() || source.parent().isGeneratedDirectory()) {
+                continue;
+            }
+
             if (source.exists().isPresent()) {
                 javaSourceFiles.addAll(
-                        source.gatherFiles((path) -> false == source.isSuperSource(path) && J2clPath.JAVA_FILES.test(path))
+                        source.gatherFiles(
+                                (path) -> false == source.isSuperSource(path) && J2clPath.JAVA_FILES.test(path)
+                        )
                 );
 
                 // add source to classpath, might be useful as it may contain non java files that are needed by annotation processors.

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
@@ -54,10 +54,8 @@ public final class J2clTaskJavacCompilerUnpackedSource<C extends J2clMavenContex
     List<J2clPath> sourceRoots(final J2clArtifact artifact,
                                final C context,
                                final TreeLogger logger) {
-        return Lists.of(
-                artifact.taskDirectory(
-                        J2clTaskKind.UNPACK
-                ).output()
+        return context.sources(
+                artifact
         );
     }
 

--- a/src/main/java/walkingkooka/j2cl/maven/unpack/J2clTaskUnpack.java
+++ b/src/main/java/walkingkooka/j2cl/maven/unpack/J2clTaskUnpack.java
@@ -57,6 +57,8 @@ public final class J2clTaskUnpack<C extends J2clMavenContext> implements J2clTas
                                   final J2clTaskKind kind,
                                   final C context,
                                   final TreeLogger logger) throws Exception {
+        this.failIfArtifactNotDependency(artifact);
+
         return this.executeIfNecessary(
                 artifact,
                 kind,
@@ -70,6 +72,8 @@ public final class J2clTaskUnpack<C extends J2clMavenContext> implements J2clTas
                                                final J2clTaskDirectory directory,
                                                final C context,
                                                final TreeLogger logger) throws Exception {
+        this.failIfArtifactNotDependency(artifact);
+
         J2clTaskResult result;
 
         final J2clPath dest = directory.output().absentOrFail();
@@ -105,6 +109,12 @@ public final class J2clTaskUnpack<C extends J2clMavenContext> implements J2clTas
         }
 
         return result;
+    }
+
+    private void failIfArtifactNotDependency(final J2clArtifact artifact) {
+        if (!artifact.isDependency()) {
+            throw new IllegalArgumentException("Unpack only expects dependencies but got " + artifact);
+        }
     }
 
     private boolean extractSourceRoots(final J2clArtifact artifact,


### PR DESCRIPTION
- the main project and dependencies have different tasks (former skipping unpack).
- saves a second when building vertispan connected.

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/571
- Skip UNPACK for project, and source from project source roots.