### PR TITLE
Watch task: Skip Javac-compile for project

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMavenContext.java
@@ -215,7 +215,9 @@ public abstract class J2clMavenContext implements Context {
         );
     }
 
-    public final J2clPath compiledBinaries(final J2clArtifact artifact) {
+    public abstract J2clPath compiledBinaries(final J2clArtifact artifact);
+
+    final J2clPath compiledBinariesTaskDirectory(final J2clArtifact artifact) {
         return artifact.taskDirectory(J2clTaskKind.JAVAC_COMPILE)
                 .output();
     }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoBuildMavenContext.java
@@ -149,6 +149,11 @@ final class J2clMojoBuildMavenContext extends J2clMavenContext {
         return hash;
     }
 
+    @Override
+    public J2clPath compiledBinaries(final J2clArtifact artifact) {
+        return this.compiledBinariesTaskDirectory(artifact);
+    }
+
     // tasks....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoTestMavenContext.java
@@ -167,6 +167,11 @@ public final class J2clMojoTestMavenContext extends J2clMavenContext {
 
     private J2clArtifact project;
 
+    @Override
+    public J2clPath compiledBinaries(final J2clArtifact artifact) {
+        return this.compiledBinariesTaskDirectory(artifact);
+    }
+
     // tasks............................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
@@ -101,6 +101,9 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     private J2clMojoWatchMavenContext context() {
         return J2clMojoWatchMavenContext.with(
                 this.cache(),
+                J2clPath.with(
+                        this.buildOutputDirectory()
+                ),
                 this.output(),
                 this.classpathScope(),
                 this.classpathRequired(),

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -35,6 +35,7 @@ import java.util.Set;
 final class J2clMojoWatchMavenContext extends J2clMavenContext {
 
     static J2clMojoWatchMavenContext with(final J2clPath cache,
+                                          final J2clPath buildOutputDirectory,
                                           final J2clPath target,
                                           final J2clClasspathScope scope,
                                           final List<J2clArtifactCoords> classpathRequired,
@@ -54,6 +55,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
                                           final MavenLogger logger) {
         return new J2clMojoWatchMavenContext(
                 cache,
+                buildOutputDirectory,
                 target,
                 scope,
                 classpathRequired,
@@ -75,6 +77,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
     }
 
     private J2clMojoWatchMavenContext(final J2clPath cache,
+                                      final J2clPath buildOutputDirectory,
                                       final J2clPath target,
                                       final J2clClasspathScope scope,
                                       final List<J2clArtifactCoords> classpathRequired,
@@ -110,6 +113,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
                 threadPoolSize,
                 logger
         );
+        this.buildOutputDirectory = buildOutputDirectory;
         this.entryPoints = entryPoints;
         this.initialScriptFilename = initialScriptFilename;
     }
@@ -151,6 +155,23 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
         return hash;
     }
 
+    /**
+     * Return the target directory if the artifact is the main project and in file event phase
+     */
+    @Override
+    public J2clPath compiledBinaries(final J2clArtifact artifact) {
+        return artifact.isDependency() ?
+                this.compiledBinariesTaskDirectory(artifact) :
+                this.buildOutputDirectory;
+    }
+
+    /**
+     * Where the IDE builds source and places the resulting class files.
+     * <br>
+     * /target/classes
+     */
+    private final J2clPath buildOutputDirectory;
+
     // tasks............................................................................................................
 
     @Override
@@ -179,7 +200,6 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
 
     private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
             J2clTaskKind.HASH,
-            J2clTaskKind.JAVAC_COMPILE,
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
             J2clTaskKind.SHADE_JAVA_SOURCE,

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompiler.java
@@ -27,6 +27,7 @@ import walkingkooka.j2cl.maven.J2clTaskKind;
 import walkingkooka.j2cl.maven.J2clTaskResult;
 import walkingkooka.j2cl.maven.log.TreeLogger;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -101,13 +102,19 @@ abstract class J2clTaskJavacCompiler<C extends J2clMavenContext> implements J2cl
                     classpath
             );
 
-            result = JavacCompiler.execute(bootstrap,
+            result = JavacCompiler.execute(
+                    bootstrap,
                     classpath,
                     javaSourceFiles,
-                    directory.output().absentOrFail(),
+                    this.compilerOutput(
+                            directory,
+                            artifact,
+                            context
+                    ),
                     context.javaCompilerArguments(),
                     shouldRunAnnotationProcessors,
-                    logger) ?
+                    logger
+            ) ?
                     J2clTaskResult.SUCCESS :
                     J2clTaskResult.FAILED;
             if (J2clTaskResult.SUCCESS == result) {
@@ -134,6 +141,13 @@ abstract class J2clTaskJavacCompiler<C extends J2clMavenContext> implements J2cl
      * This task this is used to build the classpath for the java compiler.
      */
     abstract List<J2clTaskKind> compiledBinaryTasks();
+
+    /**
+     * Directory where the class files are written.
+     */
+    abstract J2clPath compilerOutput(final J2clTaskDirectory directory,
+                                     final J2clArtifact artifact,
+                                     final C context) throws IOException;
 
     /**
      * Returns whether annotations processors should be run. Running on the original source will return YES and running on the gwt-stripped-source will return NO.

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerGwtIncompatibleStrippedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerGwtIncompatibleStrippedSource.java
@@ -26,6 +26,7 @@ import walkingkooka.j2cl.maven.J2clTaskDirectory;
 import walkingkooka.j2cl.maven.J2clTaskKind;
 import walkingkooka.j2cl.maven.log.TreeLogger;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -64,6 +65,14 @@ public final class J2clTaskJavacCompilerGwtIncompatibleStrippedSource<C extends 
                 J2clTaskKind.SHADE_CLASS_FILES,
                 J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE
         );
+    }
+
+    @Override
+    J2clPath compilerOutput(final J2clTaskDirectory directory,
+                            final J2clArtifact artifact,
+                            final C context) throws IOException {
+        return directory.output()
+                .absentOrFail();
     }
 
     @Override

--- a/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/J2clTaskJavacCompilerUnpackedSource.java
@@ -28,6 +28,7 @@ import walkingkooka.j2cl.maven.J2clTaskKind;
 import walkingkooka.j2cl.maven.log.TreeLogger;
 import walkingkooka.text.CharSequences;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
@@ -62,6 +63,15 @@ public final class J2clTaskJavacCompilerUnpackedSource<C extends J2clMavenContex
     @Override
     List<J2clTaskKind> compiledBinaryTasks() {
         return Lists.of(J2clTaskKind.JAVAC_COMPILE);
+    }
+
+    @Override
+    J2clPath compilerOutput(final J2clTaskDirectory directory,
+                            final J2clArtifact artifact,
+                            final C context) throws IOException {
+
+        return context.compiledBinaries(artifact)
+                .createIfNecessary();
     }
 
     @Override


### PR DESCRIPTION
- Saves about 1 second (10%) during a rebuild after a file change, using vertispan/connected

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/570
- Watch file event phase should be able to skip UNPACK and JAVAC-COMPILE tasks.