### PR TITLE
transpile parameters debug guard

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/transpile/J2clTranspiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/transpile/J2clTranspiler.java
@@ -71,16 +71,18 @@ final class J2clTranspiler {
                 }
             }
 
-            logger.line("Parameters");
-            logger.indent();
-            {
-                logger.paths("Classpath(s)", classpath, TreeFormat.FLAT);
-                logger.fileInfos("*.java source(s)", javaInput, TreeFormat.TREE);
-                logger.fileInfos("*.native.js source(s)", nativeJsInput, TreeFormat.TREE);
-                logger.paths("*.js source(s)", jsInput, TreeFormat.TREE);
-                logger.path("Output", output);
+            if (logger.isDebugEnabled()) {
+                logger.line("Parameters");
+                logger.indent();
+                {
+                    logger.paths("Classpath(s)", classpath, TreeFormat.FLAT);
+                    logger.fileInfos("*.java source(s)", javaInput, TreeFormat.TREE);
+                    logger.fileInfos("*.native.js source(s)", nativeJsInput, TreeFormat.TREE);
+                    logger.paths("*.js source(s)", jsInput, TreeFormat.TREE);
+                    logger.path("Output", output);
+                }
+                logger.outdent();
             }
-            logger.outdent();
 
             logger.line("J2clTranspiler");
             logger.indent();


### PR DESCRIPTION
- Previously when level NOT debug, "parameters" would be logged without any parameter values. The label is now skipped when values are skipped.