### PR TITLE
javac tasks logger debug guard around parameters logging

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/javac/JavacCompiler.java
+++ b/src/main/java/walkingkooka/j2cl/maven/javac/JavacCompiler.java
@@ -69,16 +69,18 @@ final class JavacCompiler {
 
         final boolean success;
         {
-            logger.line("Parameters");
-            logger.indent();
-            {
-                logger.paths("Bootstrap", bootstrap, TreeFormat.FLAT);
-                logger.paths("Classpath(s)", classpath, TreeFormat.FLAT);
-                logger.paths("New java file(s)", newSourceFiles, TreeFormat.TREE); // order should not be important so tree
-                logger.path("Output", newClassFilesOutput);
-                logger.strings("Option(s)", options);
+            if (logger.isDebugEnabled()) {
+                logger.line("Parameters");
+                logger.indent();
+                {
+                    logger.paths("Bootstrap", bootstrap, TreeFormat.FLAT);
+                    logger.paths("Classpath(s)", classpath, TreeFormat.FLAT);
+                    logger.paths("New java file(s)", newSourceFiles, TreeFormat.TREE); // order should not be important so tree
+                    logger.path("Output", newClassFilesOutput);
+                    logger.strings("Option(s)", options);
+                }
+                logger.outdent();
             }
-            logger.outdent();
 
             logger.line("Messages");
             logger.emptyLine();


### PR DESCRIPTION
- Closes https://github.com/mP1/j2cl-maven-plugin/issues/606
- when logging NOT debug, compile tasks print "Parameters" without any parameter values.