### PR TITLE
clean task: leaves empty cache dir

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoClean.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoClean.java
@@ -22,7 +22,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.IOException;
 
 /**
- * Cleans by deleting the ENTIRE cache directory.
+ * Cleans by deleting the ENTIRE cache directory leaving it empty.
  */
 @Mojo(name = "clean", aggregator = true)
 public class J2clMojoClean extends J2clMojo {

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -397,14 +397,27 @@ public final class J2clPath implements Comparable<J2clPath> {
      * Performs a recursive file delete on this path.
      */
     public J2clPath removeAll() throws IOException {
-        Files.walkFileTree(this.path(),
+        Files.walkFileTree(
+                this.path(),
                 new SimpleFileVisitor<>() {
+
+                    @Override
+                    public FileVisitResult preVisitDirectory(final Path dir,
+                                                             final BasicFileAttributes attrs) throws IOException {
+                        this.directoryDepth++;
+                        return super.preVisitDirectory(dir, attrs);
+                    }
+
                     @Override
                     public FileVisitResult postVisitDirectory(final Path dir,
                                                               final IOException cause) throws IOException {
-                        Files.delete(dir);
+                        if (this.directoryDepth-- > 1) {
+                            Files.delete(dir);
+                        }
                         return FileVisitResult.CONTINUE;
                     }
+
+                    private int directoryDepth = 0;
 
                     @Override
                     public FileVisitResult visitFile(final Path file,
@@ -412,7 +425,8 @@ public final class J2clPath implements Comparable<J2clPath> {
                         Files.delete(file);
                         return FileVisitResult.CONTINUE;
                     }
-                });
+                }
+        );
         return this;
     }
 

--- a/src/test/java/walkingkooka/j2cl/maven/J2clPathTest.java
+++ b/src/test/java/walkingkooka/j2cl/maven/J2clPathTest.java
@@ -223,7 +223,7 @@ public final class J2clPathTest implements ComparableTesting2<J2clPath>, HashCod
 
         this.absentCheck(file);
         this.absentCheck(dir);
-        this.absentCheck(path);
+        this.existsCheck(path);
     }
 
     @Test


### PR DESCRIPTION
- J2clPath.removeAll leaves parent dir but deletes all child dir/files.