### PR TITLE
Watch task: file event rebuild without hashes

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
@@ -127,7 +127,7 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
     private void waitAndBuild(final Path buildOutputDirectory, final J2clArtifact project,
                               final TreeLogger logger,
                               final J2clMojoWatchMavenContext context) {
-        context.fileEventPhase = true;
+        context.fileEventRebuildPhase = true;
 
         for (; ; ) {
             try (final WatchService watchService = watchService(buildOutputDirectory)) {
@@ -213,8 +213,19 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
 
     private void build(final J2clArtifact project,
                        final TreeLogger logger,
-                       final J2clMojoWatchMavenContext context) {
+                       final J2clMojoWatchMavenContext context) throws IOException {
         final Instant start = Instant.now();
+
+        // the cache directory will not have a hash and will have a trailing "-watch"
+        final J2clPath output = project.setDirectory("watch")
+                .directory();
+
+        // empty the previous watch rebuild or create an empty dir
+        if (output.exists().isPresent()) {
+            output.removeAll();
+        } else {
+            output.createIfNecessary();
+        }
 
         logger.info("Build");
         logger.indent();

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -178,7 +178,9 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
     List<J2clTaskKind> tasks(final J2clArtifact artifact) {
         return artifact.isDependency() ?
                 DEPENDENCY_TASKS :
-                PROJECT_TASKS;
+                this.fileEventRebuildPhase ?
+                        FILE_EVENT_REBUILD_PROJECT_TASKS :
+                        BUILD_PROJECT_TASKS;
     }
 
     /**
@@ -196,8 +198,18 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
             J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT
     );
 
-    private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
+    private final List<J2clTaskKind> BUILD_PROJECT_TASKS = Lists.of(
             J2clTaskKind.HASH,
+            J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
+            J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
+            J2clTaskKind.SHADE_JAVA_SOURCE,
+            J2clTaskKind.SHADE_CLASS_FILES,
+            J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT,
+            J2clTaskKind.CLOSURE_COMPILE,
+            J2clTaskKind.OUTPUT_ASSEMBLE
+    );
+
+    private final List<J2clTaskKind> FILE_EVENT_REBUILD_PROJECT_TASKS = Lists.of(
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
             J2clTaskKind.SHADE_JAVA_SOURCE,
@@ -209,15 +221,15 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
 
     @Override
     public boolean shouldCheckCache() {
-        return false == this.fileEventPhase;
+        return false == this.fileEventRebuildPhase;
     }
 
     // J2clMavenContext.................................................................................................
 
     @Override
     boolean shouldSkipSubmittingDependencyTasks() {
-        return this.fileEventPhase;
+        return this.fileEventRebuildPhase;
     }
 
-    boolean fileEventPhase = false;
+    boolean fileEventRebuildPhase = false;
 }


### PR DESCRIPTION
- rebuilds of project now skip hash task.
- rebuild of project dir now has a "-watch" suffix and no hash.
- saves about a second, reducing vertispan/connected from 11ish to 9ish.

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/603
- Watch task: file event rebuild should skip hash task