### PR TITLE
Improved cached task marker/result interpretation

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clTaskKind.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clTaskKind.java
@@ -205,8 +205,6 @@ public enum J2clTaskKind {
 
                 result.path(directory)
                         .createIfNecessary();
-
-                result.reportIfFailure(artifact, this);
             }
             return result.next(
                     artifact,


### PR DESCRIPTION
- retries a failed cache result, idea is supports retrying a task which might have failed due to network issues.
- Previously a HASH result of ABORTED was interpreted as success, the actual result of the last task was never checked (this has been fixed)
- Aborted tasks, will now be retried when maven task is re-run.

- Closes https://github.com/mP1/j2cl-maven-plugin/issues/614
- Repeating a maven:task will report SUCCESS even when required tasks have failed(!FAIL).