### PR TITLE
watch task: never hashes

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatch.java
@@ -80,6 +80,9 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
                     logger,
                     context
             );
+
+            this.prepareWatchBuild(project);
+
             context.prepareAndStart(
                     project,
                     logger
@@ -222,16 +225,7 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
                        final J2clMojoWatchMavenContext context) throws IOException {
         final Instant start = Instant.now();
 
-        // the cache directory will not have a hash and will have a trailing "-watch"
-        final J2clPath output = project.setDirectory("watch")
-                .directory();
-
-        // empty the previous watch rebuild or create an empty dir
-        if (output.exists().isPresent()) {
-            output.removeAll();
-        } else {
-            output.createIfNecessary();
-        }
+        this.prepareWatchBuild(project);
 
         logger.info("Build");
         logger.indent();
@@ -253,5 +247,18 @@ public final class J2clMojoWatch extends J2clMojoBuildWatch {
                         Instant.now()
                 )
         );
+    }
+
+    private void prepareWatchBuild(final J2clArtifact project) throws IOException {
+        // the cache directory will not have a hash and will have a trailing "-watch"
+        final J2clPath output = project.setDirectory("watch")
+                .directory();
+
+        // empty the previous watch rebuild or create an empty dir
+        if (output.exists().isPresent()) {
+            output.removeAll();
+        } else {
+            output.createIfNecessary();
+        }
     }
 }

--- a/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clMojoWatchMavenContext.java
@@ -178,9 +178,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
     List<J2clTaskKind> tasks(final J2clArtifact artifact) {
         return artifact.isDependency() ?
                 DEPENDENCY_TASKS :
-                this.fileEventRebuildPhase ?
-                        FILE_EVENT_REBUILD_PROJECT_TASKS :
-                        BUILD_PROJECT_TASKS;
+                PROJECT_TASKS;
     }
 
     /**
@@ -198,18 +196,7 @@ final class J2clMojoWatchMavenContext extends J2clMavenContext {
             J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT
     );
 
-    private final List<J2clTaskKind> BUILD_PROJECT_TASKS = Lists.of(
-            J2clTaskKind.HASH,
-            J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
-            J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
-            J2clTaskKind.SHADE_JAVA_SOURCE,
-            J2clTaskKind.SHADE_CLASS_FILES,
-            J2clTaskKind.TRANSPILE_JAVA_TO_JAVASCRIPT,
-            J2clTaskKind.CLOSURE_COMPILE,
-            J2clTaskKind.OUTPUT_ASSEMBLE
-    );
-
-    private final List<J2clTaskKind> FILE_EVENT_REBUILD_PROJECT_TASKS = Lists.of(
+    private final List<J2clTaskKind> PROJECT_TASKS = Lists.of(
             J2clTaskKind.GWT_INCOMPATIBLE_STRIP_JAVA_SOURCE,
             J2clTaskKind.JAVAC_COMPILE_GWT_INCOMPATIBLE_STRIPPED_JAVA_SOURCE,
             J2clTaskKind.SHADE_JAVA_SOURCE,


### PR DESCRIPTION
- Previously the first build hashed the project while rebuilds after a file event did not.
- The first build now does not hash