### PR TITLE
- walkingkooka-j2cl-maven-plugin-ignored-files.txt root only.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -531,8 +531,8 @@ There are several ways to ignore an artifact:
 
 ## Ignored file(s)
 
-A text file called ``.walkingkooka-j2cl-maven-plugin-ignored-files.txt`` with file paths or glob patterns that will
-result in any matched files being ignored.
+A text file called ``.walkingkooka-j2cl-maven-plugin-ignored-files.txt`` in the root - with file paths or glob patterns
+that will result in any matched files being ignored.
 
 - Blank lines are ignored
 - Lines beginning with HASH are considered to be comments and are ignored.

--- a/src/it/ignored-files/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/it/ignored-files/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -1,5 +1,12 @@
 # Patterns in this file should match files in this package and its sub package.
 
-IgnoredFile.*
+#
+# /lib/IgnoredFile1.java
+#
+lib/IgnoredFile1.*
+
+#
+# /lib/sub/IgnoredFile2.java
+#
 **/IgnoredFile2.*
 

--- a/src/it/ignored-files/src/main/java/lib/IgnoredFile1.java
+++ b/src/it/ignored-files/src/main/java/lib/IgnoredFile1.java
@@ -2,7 +2,7 @@ package lib;
 
 import java.io.File;
 
-public class IgnoredFile {
+public class IgnoredFile1 {
 
     public File file() {
         return null;


### PR DESCRIPTION
- The *.txt file can only appear in the root of a source root. Previously each directory in the source roots could have a ignore file txt with patterns return to that dir, this has been removed.