### PR TITLE
TreeLogger synchronize methods to try fix StringBuilder.append(String…

### DIFF
--- a/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
+++ b/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
@@ -387,7 +387,7 @@ final public class TreeLogger {
         this.flush();
     }
 
-    public void log(final CharSequence line) {
+    public synchronized void log(final CharSequence line) {
         this.info.print(line);
     }
 
@@ -398,7 +398,7 @@ final public class TreeLogger {
         );
     }
 
-    public void indentedLine(final CharSequence line) {
+    public synchronized void indentedLine(final CharSequence line) {
         this.indent();
         {
             this.line(line);
@@ -415,12 +415,12 @@ final public class TreeLogger {
         printer.print(line);
     }
 
-    public void emptyLine() {
+    public synchronized void emptyLine() {
         this.info.lineStart();
         this.info.print(this.info.lineEnding());
     }
 
-    public void lineStart() {
+    public synchronized void lineStart() {
         this.info.lineStart();
     }
 
@@ -428,12 +428,12 @@ final public class TreeLogger {
         this.line("*** END ***");
     }
 
-    public void outdent() {
+    public synchronized void outdent() {
         this.debug.outdent();
         this.info.outdent();
     }
 
-    public void flush() {
+    public synchronized void flush() {
         this.debug.flush();
         this.info.flush();
     }
@@ -443,13 +443,13 @@ final public class TreeLogger {
     private final IndentingPrinter info;
 
 
-    public void debug(final CharSequence line) {
+    public synchronized void debug(final CharSequence line) {
         this.debugConsumer.accept(line);
     }
 
     private final Consumer<CharSequence> debugConsumer;
 
-    public void info(final CharSequence line) {
+    public synchronized void info(final CharSequence line) {
         this.infoConsumer.accept(line);
     }
 


### PR DESCRIPTION
…) IOOBE

- very rarely happens maybe 1 in 500+

Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 76 out of bounds for length 34
    at java.lang.AbstractStringBuilder.append (AbstractStringBuilder.java:750)
    at java.lang.StringBuilder.append (StringBuilder.java:241)
    at walkingkooka.text.printer.PrintedLineHandlerPrinter.printToBuffer (PrintedLineHandlerPrinter.java:146)
    at walkingkooka.text.printer.PrintedLineHandlerPrinter.print (PrintedLineHandlerPrinter.java:58)
    at walkingkooka.text.printer.BasicIndentingPrinter.print0 (BasicIndentingPrinter.java:110)
    at walkingkooka.text.printer.BasicIndentingPrinter.print (BasicIndentingPrinter.java:76)
    at walkingkooka.j2cl.maven.log.TreeLogger.line0 (TreeLogger.java:415)
    at walkingkooka.j2cl.maven.log.TreeLogger.line (TreeLogger.java:410)
    at walkingkooka.j2cl.maven.J2clMavenContext.callable (J2clMavenContext.java:435)
    at walkingkooka.j2cl.maven.J2clMavenContext.lambda$trySubmitTasks$2 (J2clMavenContext.java:394)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:515)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    at java.lang.Thread.run (Thread.java:834)
[ERROR]