### PR TITLE
POM webdrivermanager 5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,15 +154,14 @@
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.0</version>
             </dependency>
-
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
             </dependency>
 
             <!--
@@ -409,7 +408,7 @@ and
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.6.2</version>
+            <version>5.7.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- Hopefully fixes WDM startup fails with exceptions such as

> 2024-03-24T12:11:36.6708426Z [ERROR]         Failed to execute walkingkooka:walkingkooka-spreadsheet-server-it-junit-test:jar:1.0-JUNIT_TESTS message: java.lang.NumberFormatException: For input string: "public"
  2024-03-24T12:11:36.6709746Z io.github.bonigarcia.wdm.config.WebDriverManagerException: java.lang.NumberFormatException: For input string: "public"