### PR TITLE
Maven POM upgrade to java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -559,8 +559,8 @@ and
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>11</source>
+                    <target>11</target>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- Required because some dependencies are java11 was java9