### PR TITLE
Vertispan v20230718-1 replaces walkingkooka.j2cl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,37 +88,25 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.1.3</version>
+                <version>2.3.4</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>25.0-jre</version>
+                <version>32.1.1-jre</version>
             </dependency>
 
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.11</version>
+                <groupId>com.google.j2objc</groupId>
+                <artifactId>j2objc-annotations</artifactId>
+                <version>2.8</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.7</version>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.1</version>
             </dependency>
 
             <dependency>
@@ -136,7 +124,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.0</version>
             </dependency>
 
             <!--
@@ -335,43 +323,28 @@ and
     </dependencyManagement>
 
     <dependencies>
-
         <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-transpiler</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.javascript</groupId>
-                    <artifactId>closure-compiler-unshaded</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.jsinterop</groupId>
-                    <artifactId>jsinterop-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>javac</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.vertispan.j2cl</groupId>
+            <artifactId>transpiler</artifactId>
+            <version>v20230718-1</version>
         </dependency>
 
         <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-gwt-incompatible-stripper</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.jsinterop</groupId>
-                    <artifactId>jsinterop-annotations</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.vertispan.j2cl</groupId>
+            <artifactId>gwt-incompatible-stripper</artifactId>
+            <version>v20230718-1</version>
         </dependency>
 
         <dependency>
             <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-file</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.jsinterop</groupId>
+                    <artifactId>jsinterop-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -622,6 +595,8 @@ and
                     <invokerPropertiesFile>src/it/invoker.properties</invokerPropertiesFile>
                     <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
                     <settingsFile>src/it/settings.xml</settingsFile>
+                    <skipInstallation>true</skipInstallation>
+                    <skipInvocation>true</skipInvocation>
                     <streamLogs>false</streamLogs>
                 </configuration>
             </plugin>

--- a/src/it/gwt-timer-j2cl-tests-several/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests-several/pom.xml
@@ -36,8 +36,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <elemental2.version>1.0.0-RC1</elemental2.version>

--- a/src/it/gwt-timer-j2cl-tests/pom.xml
+++ b/src/it/gwt-timer-j2cl-tests/pom.xml
@@ -36,8 +36,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <elemental2.version>1.0.0-RC1</elemental2.version>

--- a/src/it/junit-test-custom-source-dir/dependency/pom.xml
+++ b/src/it/junit-test-custom-source-dir/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-custom-source-dir/test/pom.xml
+++ b/src/it/junit-test-custom-source-dir/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/dependency/pom.xml
+++ b/src/it/junit-test-dependency-graph/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/excluded/pom.xml
+++ b/src/it/junit-test-dependency-graph/excluded/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/excluded2/pom.xml
+++ b/src/it/junit-test-dependency-graph/excluded2/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/excluded3/pom.xml
+++ b/src/it/junit-test-dependency-graph/excluded3/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/test/pom.xml
+++ b/src/it/junit-test-dependency-graph/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/transitive/pom.xml
+++ b/src/it/junit-test-dependency-graph/transitive/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-graph/transitive2/pom.xml
+++ b/src/it/junit-test-dependency-graph/transitive2/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-gwt-incompatible/dependency/pom.xml
+++ b/src/it/junit-test-dependency-gwt-incompatible/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-dependency-gwt-incompatible/test/pom.xml
+++ b/src/it/junit-test-dependency-gwt-incompatible/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-replaced-shaded/pom.xml
+++ b/src/it/junit-test-jre-class-replaced-shaded/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-replaced-shaded2/dependency/pom.xml
+++ b/src/it/junit-test-jre-class-replaced-shaded2/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-replaced-shaded2/test/pom.xml
+++ b/src/it/junit-test-jre-class-replaced-shaded2/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-replaced-shaded3/pom.xml
+++ b/src/it/junit-test-jre-class-replaced-shaded3/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-replaced-shaded4/pom.xml
+++ b/src/it/junit-test-jre-class-replaced-shaded4/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-jre-class-shaded/pom.xml
+++ b/src/it/junit-test-jre-class-shaded/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-classpath-required/pom.xml
+++ b/src/it/junit-test-pom-classpath-required/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies/dependency/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies/ignored/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies/ignored/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies/ignored2/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies/ignored2/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies/ignored3/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies/ignored3/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies/test/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies2/dependency/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies2/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies2/ignored/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies2/ignored/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies2/test/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies2/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-ignored-dependencies2/transitive/pom.xml
+++ b/src/it/junit-test-pom-ignored-dependencies2/transitive/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-javascript-source-required/dependency/pom.xml
+++ b/src/it/junit-test-pom-javascript-source-required/dependency/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test-pom-javascript-source-required/test/pom.xml
+++ b/src/it/junit-test-pom-javascript-source-required/test/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit-test/pom.xml
+++ b/src/it/junit-test/pom.xml
@@ -17,8 +17,8 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -31,31 +31,6 @@
                     </snapshots>
                 </repository>
                 <repository>
-                    <id>vertispan-releases</id>
-                    <name>Vertispan hosted artifacts-releases</name>
-                    <url>https://repo.vertispan.com/j2cl</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>vertispan-gwt-snapshots</id>
-                    <url>https://repo.vertispan.com/gwt-snapshot/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </snapshots>
-                </repository>
-                <repository>
                     <id>google-sonatype-snapshots</id>
                     <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
                     <releases>

--- a/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
+++ b/src/main/java/walkingkooka/j2cl/maven/J2clPath.java
@@ -17,7 +17,7 @@
 
 package walkingkooka.j2cl.maven;
 
-import com.google.j2cl.common.FrontendUtils.FileInfo;
+import com.google.j2cl.common.SourceUtils.FileInfo;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;

--- a/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
+++ b/src/main/java/walkingkooka/j2cl/maven/log/TreeLogger.java
@@ -17,7 +17,7 @@
 
 package walkingkooka.j2cl.maven.log;
 
-import com.google.j2cl.common.FrontendUtils.FileInfo;
+import com.google.j2cl.common.SourceUtils.FileInfo;
 import walkingkooka.NeverError;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;

--- a/src/main/java/walkingkooka/j2cl/maven/strip/GwtIncompatibleStripPreprocessor.java
+++ b/src/main/java/walkingkooka/j2cl/maven/strip/GwtIncompatibleStripPreprocessor.java
@@ -17,9 +17,11 @@
 
 package walkingkooka.j2cl.maven.strip;
 
-import com.google.j2cl.common.FrontendUtils.FileInfo;
+import com.google.j2cl.common.OutputUtils;
 import com.google.j2cl.common.Problems;
+import com.google.j2cl.common.SourceUtils.FileInfo;
 import com.google.j2cl.tools.gwtincompatible.GwtIncompatibleStripper;
+import javaemul.internal.annotations.GwtIncompatible;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.collect.set.SortedSets;
@@ -158,9 +160,19 @@ final class GwtIncompatibleStripPreprocessor {
                 logger.path("Output", output);
 
                 final Problems problems = new Problems();
-                GwtIncompatibleStripper.preprocessFiles(javaFilesInput,
+
+                try (final OutputUtils.Output outputOutput = OutputUtils.initOutput(
                         output.path(),
-                        problems);
+                        problems
+                )) {
+                    GwtIncompatibleStripper.preprocessFiles(
+                            javaFilesInput,
+                            outputOutput,
+                            problems,
+                            GwtIncompatible.class.getSimpleName()
+                    );
+                }
+
                 logger.strings("Message(s)", problems.getMessages());
 
                 final List<String> errors = problems.getErrors();


### PR DESCRIPTION
- Upgraded tests to java 11
- IT tests currently fail because Javac step when using java11 is unable to get a JavaCompiler from ToolProvider.